### PR TITLE
arm64: dts: msm8916-samsung-a2015-common: add gpio-based buttons and …

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-a2015-common-pins.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-a2015-common-pins.dtsi
@@ -12,6 +12,7 @@
 			bias-disable;
 		};
 	};
+	
 	ts_int_default: ts_int_default {
 		pinmux {
 			function = "gpio";
@@ -19,6 +20,32 @@
 		};
 		pinconf {
 			pins = "gpio13";
+			drive-strength = <2>;
+			bias-disable;
+		};
+	};
+	
+	gpio_keys_default: gpio_keys_default {
+		pinmux {
+			function = "gpio";
+			pins = "gpio107", "gpio109";
+		};
+
+		pinconf {
+			pins = "gpio107", "gpio109";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
+
+	gpio_hall_sensor_default: gpio_hall_sensor_default {
+		pinmux {
+			function = "gpio";
+			pins = "gpio52";
+		};
+
+		pinconf {
+			pins = "gpio52";
 			drive-strength = <2>;
 			bias-disable;
 		};

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-a2015-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-a2015-common.dtsi
@@ -4,6 +4,7 @@
 #include "pm8916.dtsi"
 #include "msm8916-samsung-a2015-common-pins.dtsi"
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 #include <dt-bindings/sound/apq8016-lpass.h>
 
@@ -82,6 +83,40 @@
 			pinctrl-names = "default", "sleep";
 			pinctrl-0 = <&blsp1_uart2_default>;
 			pinctrl-1 = <&blsp1_uart2_sleep>;
+		};
+
+		gpio-keys {
+			compatible = "gpio-keys";
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&gpio_keys_default>;
+
+			volume-up {
+				label = "Volume Up";
+				gpios = <&msmgpio 107 GPIO_ACTIVE_LOW>;
+				linux,code = <KEY_VOLUMEUP>;
+			};
+
+			home {
+				label = "Home";
+				gpios = <&msmgpio 109 GPIO_ACTIVE_LOW>;
+				linux,code = <KEY_HOMEPAGE>;
+			};
+		};
+
+		gpio-hall-sensor {
+			compatible = "gpio-keys";
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&gpio_hall_sensor_default>;
+
+			hall-sensor {
+				label = "Hall Effect Sensor";
+				gpios = <&msmgpio 52 GPIO_ACTIVE_LOW>;
+				linux,input-type = <EV_SW>;
+				linux,code = <SW_LID>;
+				linux,can-disable;
+			};
 		};
 
 		usb@78d9000 {
@@ -281,5 +316,18 @@
 	l18 {
 		regulator-min-microvolt = <2700000>;
 		regulator-max-microvolt = <2700000>;
+	};
+};
+
+&spmi_bus {
+	pm8916@0 {
+		pon@800 {
+			volume-down {
+				compatible = "qcom,pm8941-resin";
+				interrupts = <0x0 0x8 1 IRQ_TYPE_EDGE_BOTH>;
+				bias-pull-up;
+				linux,code = <KEY_VOLUMEDOWN>;
+			};
+		};
 	};
 };


### PR DESCRIPTION
…a gpio based hall sensor; add volume down (pm8941-resin)