### PR TITLE
HACK: Implement SMP without PSCI

### DIFF
--- a/Documentation/devicetree/bindings/arm/cpus.yaml
+++ b/Documentation/devicetree/bindings/arm/cpus.yaml
@@ -199,6 +199,7 @@ patternProperties:
             - enum:
                 - psci
                 - spin-table
+                - qcom,arm-cortex-acc
             # On ARM 32-bit systems this property is optional
             - enum:
                 - actions,s500-smp

--- a/Documentation/devicetree/bindings/arm/msm/acc.txt
+++ b/Documentation/devicetree/bindings/arm/msm/acc.txt
@@ -1,0 +1,19 @@
+Application Processor Sub-system (APSS) Application Clock Controller (ACC)
+
+The ACC provides clock, power domain, and reset control to a CPU. There is one ACC
+register region per CPU within the APSS remapped region as well as an alias register
+region that remaps accesses to the ACC associated with the CPU accessing the region.
+
+Required properties:
+- compatible:		Must be "qcom,arm-cortex-acc"
+- reg:			The first element specifies the base address and size of
+			the register region. An optional second element specifies
+			the base address and size of the alias register region.
+
+Example:
+
+	clock-controller@b088000 {
+		compatible = "qcom,arm-cortex-acc";
+		reg = <0x0b088000 0x1000>,
+		      <0x0b008000 0x1000>;
+	}

--- a/Documentation/devicetree/bindings/arm/msm/qcom,saw2.txt
+++ b/Documentation/devicetree/bindings/arm/msm/qcom,saw2.txt
@@ -27,6 +27,7 @@ PROPERTIES
 			"qcom,apq8064-saw2-v1.1-cpu"
 			"qcom,msm8974-saw2-v2.1-cpu"
 			"qcom,apq8084-saw2-v2.1-cpu"
+			"qcom,msm8916-saw2-v3.0-cpu"
 
 - reg:
 	Usage: required

--- a/arch/arm64/boot/dts/qcom/msm8916-no-psci-sad-face.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-no-psci-sad-face.dtsi
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/ {
+	cpus {
+		cpu@0 {
+			enable-method = "qcom,arm-cortex-acc";
+			qcom,acc = <&acc0>;
+		};
+		cpu@1 {
+			enable-method = "qcom,arm-cortex-acc";
+			qcom,acc = <&acc1>;
+		};
+		cpu@2 {
+			enable-method = "qcom,arm-cortex-acc";
+			qcom,acc = <&acc2>;
+		};
+		cpu@3 {
+			enable-method = "qcom,arm-cortex-acc";
+			qcom,acc = <&acc3>;
+		};
+
+		l2-cache {
+			power-domain = <&l2ccc_0>;
+		};
+	};
+
+	psci {
+		status = "disabled";
+	};
+
+	soc {
+		l2ccc_0: clock-controller@b011000 {
+			compatible = "qcom,8916-l2ccc";
+			reg = <0x0b011000 0x1000>;
+		};
+
+		acc0: clock-controller@b088000 {
+			compatible = "qcom,arm-cortex-acc";
+			reg = <0x0b088000 0x1000>, <0x0b008000 0x1000>;
+		};
+		acc1: clock-controller@b098000 {
+			compatible = "qcom,arm-cortex-acc";
+			reg = <0x0b098000 0x1000>, <0x0b008000 0x1000>;
+		};
+		acc2: clock-controller@b0a8000 {
+			compatible = "qcom,arm-cortex-acc";
+			reg = <0x0b0a8000 0x1000>, <0x0b008000 0x1000>;
+		};
+		acc3: clock-controller@b0b8000 {
+			compatible = "qcom,arm-cortex-acc";
+			reg = <0x0b0b8000 0x1000>, <0x0b008000 0x1000>;
+		};
+	};
+};

--- a/arch/arm64/boot/dts/qcom/msm8916-no-psci-sad-face.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-no-psci-sad-face.dtsi
@@ -5,18 +5,22 @@
 		cpu@0 {
 			enable-method = "qcom,arm-cortex-acc";
 			qcom,acc = <&acc0>;
+			qcom,saw = <&saw0>;
 		};
 		cpu@1 {
 			enable-method = "qcom,arm-cortex-acc";
 			qcom,acc = <&acc1>;
+			qcom,saw = <&saw1>;
 		};
 		cpu@2 {
 			enable-method = "qcom,arm-cortex-acc";
 			qcom,acc = <&acc2>;
+			qcom,saw = <&saw2>;
 		};
 		cpu@3 {
 			enable-method = "qcom,arm-cortex-acc";
 			qcom,acc = <&acc3>;
+			qcom,saw = <&saw3>;
 		};
 
 		l2-cache {
@@ -49,6 +53,23 @@
 		acc3: clock-controller@b0b8000 {
 			compatible = "qcom,arm-cortex-acc";
 			reg = <0x0b0b8000 0x1000>, <0x0b008000 0x1000>;
+		};
+
+		saw0: power-controller@b089000 {
+			compatible = "qcom,msm8916-saw2-v3.0-cpu";
+			reg = <0xb089000 0x1000>, <0xb009000 0x1000>;
+		};
+		saw1: power-controller@b099000 {
+			compatible = "qcom,msm8916-saw2-v3.0-cpu";
+			reg = <0xb099000 0x1000>, <0xb009000 0x1000>;
+		};
+		saw2: power-controller@b0a9000 {
+			compatible = "qcom,msm8916-saw2-v3.0-cpu";
+			reg = <0xb0a9000 0x1000>, <0xb009000 0x1000>;
+		};
+		saw3: power-controller@b0b9000 {
+			compatible = "qcom,msm8916-saw2-v3.0-cpu";
+			reg = <0xb0b9000 0x1000>, <0xb009000 0x1000>;
 		};
 	};
 };

--- a/arch/arm64/boot/dts/qcom/msm8916-no-psci-sad-face.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-no-psci-sad-face.dtsi
@@ -26,6 +26,12 @@
 		l2-cache {
 			power-domain = <&l2ccc_0>;
 		};
+
+		idle-states {
+			spc {
+				compatible = "qcom,idle-state-spc", "arm,idle-state";
+			};
+		};
 	};
 
 	psci {

--- a/arch/arm64/kernel/Makefile
+++ b/arch/arm64/kernel/Makefile
@@ -21,6 +21,8 @@ obj-y			:= debug-monitors.o entry.o irq.o fpsimd.o		\
 			   smp.o smp_spin_table.o topology.o smccc-call.o	\
 			   syscall.o
 
+obj-$(CONFIG_ARCH_QCOM)	+= qcom-special-cpu-ops-dont-copy-this.o
+
 extra-$(CONFIG_EFI)			:= efi-entry.o
 
 OBJCOPYFLAGS := --prefix-symbols=__efistub_

--- a/arch/arm64/kernel/cpu_ops.c
+++ b/arch/arm64/kernel/cpu_ops.c
@@ -17,12 +17,16 @@
 extern const struct cpu_operations smp_spin_table_ops;
 extern const struct cpu_operations acpi_parking_protocol_ops;
 extern const struct cpu_operations cpu_psci_ops;
+extern const struct cpu_operations qcom_cortex_a_ops;
 
 const struct cpu_operations *cpu_ops[NR_CPUS] __ro_after_init;
 
 static const struct cpu_operations *const dt_supported_cpu_ops[] __initconst = {
 	&smp_spin_table_ops,
 	&cpu_psci_ops,
+#ifdef CONFIG_ARCH_QCOM
+	&qcom_cortex_a_ops,
+#endif
 	NULL,
 };
 

--- a/arch/arm64/kernel/qcom-special-cpu-ops-dont-copy-this.c
+++ b/arch/arm64/kernel/qcom-special-cpu-ops-dont-copy-this.c
@@ -273,9 +273,25 @@ static int qcom_cpu_boot(unsigned int cpu)
 	return ret;
 }
 
+extern int qcom_cpuidle_init(struct device_node *cpu_node, int cpu);
+extern int qcom_idle_enter(unsigned long index);
+
+static __init __maybe_unused int qcom_cpu_init_idle(unsigned int cpu)
+{
+	struct device_node *cpu_node = of_get_cpu_node(cpu, NULL);
+	if (!cpu_node)
+		return -ENODEV;
+
+	return qcom_cpuidle_init(cpu_node, cpu);
+}
+
 const struct cpu_operations qcom_cortex_a_ops = {
 	.name		= "qcom,arm-cortex-acc",
 	.cpu_init	= qcom_cpu_init,
 	.cpu_prepare	= qcom_cpu_prepare,
 	.cpu_boot	= qcom_cpu_boot,
+#ifdef CONFIG_QCOM_PM
+	.cpu_init_idle	= qcom_cpu_init_idle,
+	.cpu_suspend	= qcom_idle_enter,
+#endif
 };

--- a/arch/arm64/kernel/qcom-special-cpu-ops-dont-copy-this.c
+++ b/arch/arm64/kernel/qcom-special-cpu-ops-dont-copy-this.c
@@ -1,0 +1,281 @@
+/* Copyright (c) 2014, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2013 ARM Ltd.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 and
+ * only version 2 as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/* MSM ARMv8 CPU Operations
+ * Based on arch/arm64/kernel/smp_spin_table.c
+ */
+
+#include <linux/bitops.h>
+#include <linux/cpu.h>
+#include <linux/cpumask.h>
+#include <linux/delay.h>
+#include <linux/init.h>
+#include <linux/io.h>
+#include <linux/of.h>
+#include <linux/of_address.h>
+#include <linux/smp.h>
+#include <linux/qcom_scm.h>
+
+#include <asm/barrier.h>
+#include <asm/cacheflush.h>
+#include <asm/cpu_ops.h>
+#include <asm/cputype.h>
+#include <asm/smp_plat.h>
+
+DEFINE_PER_CPU(int, cold_boot_done);
+
+/* CPU power domain register offsets */
+#define CPU_PWR_CTL		0x4
+#define CPU_PWR_GATE_CTL	0x14
+#define LDO_BHS_PWR_CTL		0x28
+
+/* L2 power domain register offsets */
+#define L2_PWR_CTL_OVERRIDE	0xc
+#define L2_PWR_CTL		0x14
+#define L2_PWR_STATUS		0x18
+#define	L2_CORE_CBCR		0x58
+#define L1_RST_DIS		0x284
+
+#define L2_SPM_STS		0xc
+#define L2_VREG_CTL		0x1c
+
+/*
+ * struct qcom_l2ccc_of_info: represents of data for l2 cache clock controller.
+ * @compat: compat string for l2 cache clock controller
+ * @l2_pon: l2 cache power on routine
+ */
+struct qcom_l2ccc_of_info {
+	const char *compat;
+	int (*l2_power_on) (struct device_node *dn, u32 l2_mask, int cpu);
+	u32 l2_power_on_mask;
+};
+
+static int power_on_l2_msm8916(struct device_node *l2ccc_node, u32 pon_mask,
+				int cpu)
+{
+	u32 pon_status;
+	void __iomem *l2_base;
+
+	l2_base = of_iomap(l2ccc_node, 0);
+	if (!l2_base)
+		return -ENOMEM;
+
+	/* Skip power-on sequence if l2 cache is already powered up*/
+	pon_status = (__raw_readl(l2_base + L2_PWR_STATUS) & pon_mask)
+				== pon_mask;
+	if (pon_status) {
+		iounmap(l2_base);
+		return 0;
+	}
+
+	/* Close L2/SCU Logic GDHS and power up the cache */
+	writel_relaxed(0x10D700, l2_base + L2_PWR_CTL);
+
+	/* Assert PRESETDBGn */
+	writel_relaxed(0x400000, l2_base + L2_PWR_CTL_OVERRIDE);
+	mb();
+	udelay(2);
+
+	/* De-assert L2/SCU memory Clamp */
+	writel_relaxed(0x101700, l2_base + L2_PWR_CTL);
+
+	/* Wakeup L2/SCU RAMs by deasserting sleep signals */
+	writel_relaxed(0x101703, l2_base + L2_PWR_CTL);
+	mb();
+	udelay(2);
+
+	/* Enable clocks via SW_CLK_EN */
+	writel_relaxed(0x01, l2_base + L2_CORE_CBCR);
+
+	/* De-assert L2/SCU logic clamp */
+	writel_relaxed(0x101603, l2_base + L2_PWR_CTL);
+	mb();
+	udelay(2);
+
+	/* De-assert PRESSETDBg */
+	writel_relaxed(0x0, l2_base + L2_PWR_CTL_OVERRIDE);
+
+	/* De-assert L2/SCU Logic reset */
+	writel_relaxed(0x100203, l2_base + L2_PWR_CTL);
+	mb();
+	udelay(54);
+
+	/* Turn on the PMIC_APC */
+	writel_relaxed(0x10100203, l2_base + L2_PWR_CTL);
+
+	/* Set H/W clock control for the cpu CBC block */
+	writel_relaxed(0x03, l2_base + L2_CORE_CBCR);
+	mb();
+	iounmap(l2_base);
+
+	return 0;
+}
+
+static const struct qcom_l2ccc_of_info l2ccc_info[] = {
+	{
+		.compat = "qcom,8916-l2ccc",
+		.l2_power_on = power_on_l2_msm8916,
+		.l2_power_on_mask = BIT(9),
+	},
+};
+
+static int power_on_l2_cache(struct device_node *l2ccc_node, int cpu)
+{
+	int ret, i;
+	const char *compat;
+
+	ret = of_property_read_string(l2ccc_node, "compatible", &compat);
+	if (ret)
+		return ret;
+
+	for (i = 0; i < ARRAY_SIZE(l2ccc_info); i++) {
+		const struct qcom_l2ccc_of_info *ptr = &l2ccc_info[i];
+
+		if (!of_compat_cmp(ptr->compat, compat, strlen(compat)))
+				return ptr->l2_power_on(l2ccc_node,
+						ptr->l2_power_on_mask, cpu);
+	}
+	pr_err("Compat string not found for L2CCC node\n");
+	return -EIO;
+}
+
+static int qcom_unclamp_secondary_arm_cpu(unsigned int cpu)
+{
+
+	int ret = 0;
+	struct device_node *cpu_node, *acc_node, *l2_node, *l2ccc_node;
+	void __iomem *reg;
+
+	cpu_node = of_get_cpu_node(cpu, NULL);
+	if (!cpu_node)
+		return -ENODEV;
+
+	acc_node = of_parse_phandle(cpu_node, "qcom,acc", 0);
+	if (!acc_node) {
+			ret = -ENODEV;
+			goto out_acc;
+	}
+
+	l2_node = of_parse_phandle(cpu_node, "next-level-cache", 0);
+	if (!l2_node) {
+		ret = -ENODEV;
+		goto out_l2;
+	}
+
+	l2ccc_node = of_parse_phandle(l2_node, "power-domain", 0);
+	if (!l2ccc_node) {
+		ret = -ENODEV;
+		goto out_l2;
+	}
+
+	/* Ensure L2-cache of the CPU is powered on before
+	 * unclamping cpu power rails.
+	 */
+	ret = power_on_l2_cache(l2ccc_node, cpu);
+	if (ret) {
+		pr_err("L2 cache power up failed for CPU%d\n", cpu);
+		goto out_l2ccc;
+	}
+
+	reg = of_iomap(acc_node, 0);
+	if (!reg) {
+		ret = -ENOMEM;
+		goto out_acc_reg;
+	}
+
+	/* Assert Reset on cpu-n */
+	writel_relaxed(0x00000033, reg + CPU_PWR_CTL);
+	mb();
+
+	/*Program skew to 16 X0 clock cycles*/
+	writel_relaxed(0x10000001, reg + CPU_PWR_GATE_CTL);
+	mb();
+	udelay(2);
+
+	/* De-assert coremem clamp */
+	writel_relaxed(0x00000031, reg + CPU_PWR_CTL);
+	mb();
+
+	/* Close coremem array gdhs */
+	writel_relaxed(0x00000039, reg + CPU_PWR_CTL);
+	mb();
+	udelay(2);
+
+	/* De-assert cpu-n clamp */
+	writel_relaxed(0x00020038, reg + CPU_PWR_CTL);
+	mb();
+	udelay(2);
+
+	/* De-assert cpu-n reset */
+	writel_relaxed(0x00020008, reg + CPU_PWR_CTL);
+	mb();
+
+	/* Assert PWRDUP signal on core-n */
+	writel_relaxed(0x00020088, reg + CPU_PWR_CTL);
+	mb();
+
+	/* Secondary CPU-N is now alive */
+	iounmap(reg);
+out_acc_reg:
+	of_node_put(l2ccc_node);
+out_l2ccc:
+	of_node_put(l2_node);
+out_l2:
+	of_node_put(acc_node);
+out_acc:
+	of_node_put(cpu_node);
+
+	return ret;
+}
+
+static int __init qcom_cpu_init(unsigned int cpu)
+{
+	/* Mark CPU0 cold boot flag as done */
+	if (!cpu && !per_cpu(cold_boot_done, cpu))
+		per_cpu(cold_boot_done, cpu) = true;
+
+	return 0;
+}
+
+static int __init qcom_cpu_prepare(unsigned int cpu)
+{
+	const cpumask_t *mask = cpumask_of(cpu);
+
+	if (qcom_scm_set_cold_boot_addr(secondary_entry, mask)) {
+		pr_warn("CPU%d:Failed to set boot address\n", cpu);
+		return -ENOSYS;
+	}
+
+	return 0;
+}
+
+static int qcom_cpu_boot(unsigned int cpu)
+{
+	int ret = 0;
+
+	if (per_cpu(cold_boot_done, cpu) == false) {
+		ret = qcom_unclamp_secondary_arm_cpu(cpu);
+		if (ret)
+			return ret;
+		per_cpu(cold_boot_done, cpu) = true;
+	}
+
+	return ret;
+}
+
+const struct cpu_operations qcom_cortex_a_ops = {
+	.name		= "qcom,arm-cortex-acc",
+	.cpu_init	= qcom_cpu_init,
+	.cpu_prepare	= qcom_cpu_prepare,
+	.cpu_boot	= qcom_cpu_boot,
+};

--- a/drivers/firmware/qcom_scm-64.c
+++ b/drivers/firmware/qcom_scm-64.c
@@ -11,6 +11,7 @@
 #include <linux/qcom_scm.h>
 #include <linux/arm-smccc.h>
 #include <linux/dma-mapping.h>
+#include <asm/cacheflush.h>
 
 #include "qcom_scm.h"
 
@@ -106,6 +107,7 @@ static int qcom_scm_call(struct device *dev, u32 svc_id, u32 cmd_id,
 						      FIRST_EXT_ARG_IDX]);
 		}
 
+		if (dev) {
 		args_phys = dma_map_single(dev, args_virt, alloc_len,
 					   DMA_TO_DEVICE);
 
@@ -115,6 +117,10 @@ static int qcom_scm_call(struct device *dev, u32 svc_id, u32 cmd_id,
 		}
 
 		x5 = args_phys;
+		} else {
+			x5 = virt_to_phys(args_virt);
+			__flush_dcache_area(args_virt, alloc_len);
+		}
 	}
 
 	do {
@@ -146,6 +152,7 @@ static int qcom_scm_call(struct device *dev, u32 svc_id, u32 cmd_id,
 	}  while (res->a0 == QCOM_SCM_V2_EBUSY);
 
 	if (args_virt) {
+		if (dev)
 		dma_unmap_single(dev, args_phys, alloc_len, DMA_TO_DEVICE);
 		kfree(args_virt);
 	}
@@ -154,6 +161,34 @@ static int qcom_scm_call(struct device *dev, u32 svc_id, u32 cmd_id,
 		return qcom_scm_remap_error(res->a0);
 
 	return 0;
+}
+
+static int qcom_scm_set_boot_addr(struct device *dev, void *entry,
+				  const cpumask_t *cpus, int flags)
+{
+	struct qcom_scm_desc desc = {0};
+	struct arm_smccc_res res;
+	unsigned int cpu = cpumask_first(cpus);
+	u64 mpidr_el1 = cpu_logical_map(cpu);
+
+	/* For now we assume only a single cpu is set in the mask */
+	WARN_ON(cpumask_weight(cpus) != 1);
+
+	if (mpidr_el1 & ~MPIDR_HWID_BITMASK) {
+		pr_err("CPU%d: Failed to set boot address\n", cpu);
+		return -ENOSYS;
+	}
+
+	desc.args[0] = virt_to_phys(entry);
+	desc.args[1] = BIT(MPIDR_AFFINITY_LEVEL(mpidr_el1, 0));
+	desc.args[2] = BIT(MPIDR_AFFINITY_LEVEL(mpidr_el1, 1));
+	desc.args[3] = BIT(MPIDR_AFFINITY_LEVEL(mpidr_el1, 2));
+	desc.args[4] = ~0ULL;
+	desc.args[5] = QCOM_SCM_FLAG_HLOS | flags;
+	desc.arginfo = QCOM_SCM_ARGS(6);
+
+	return qcom_scm_call(dev, QCOM_SCM_SVC_BOOT, QCOM_SCM_BOOT_ADDR_MC,
+			     &desc, &res);
 }
 
 /**
@@ -166,7 +201,13 @@ static int qcom_scm_call(struct device *dev, u32 svc_id, u32 cmd_id,
  */
 int __qcom_scm_set_cold_boot_addr(void *entry, const cpumask_t *cpus)
 {
-	return -ENOTSUPP;
+	if (qcom_smccc_convention == -1) {
+		// This is called long before the driver is probed
+		__qcom_scm_init();
+	}
+
+	return qcom_scm_set_boot_addr(NULL, entry, cpus,
+				      QCOM_SCM_FLAG_COLDBOOT_MC);
 }
 
 /**
@@ -181,7 +222,8 @@ int __qcom_scm_set_cold_boot_addr(void *entry, const cpumask_t *cpus)
 int __qcom_scm_set_warm_boot_addr(struct device *dev, void *entry,
 				  const cpumask_t *cpus)
 {
-	return -ENOTSUPP;
+	return qcom_scm_set_boot_addr(dev, entry, cpus,
+				      QCOM_SCM_FLAG_WARMBOOT_MC);
 }
 
 /**

--- a/drivers/soc/qcom/Kconfig
+++ b/drivers/soc/qcom/Kconfig
@@ -64,7 +64,7 @@ config QCOM_MDT_LOADER
 
 config QCOM_PM
 	bool "Qualcomm Power Management"
-	depends on ARCH_QCOM && !ARM64
+	depends on ARCH_QCOM
 	select ARM_CPU_SUSPEND
 	select QCOM_SCM
 	help

--- a/drivers/soc/qcom/spm.c
+++ b/drivers/soc/qcom/spm.c
@@ -53,7 +53,7 @@ enum spm_reg {
 };
 
 struct spm_reg_data {
-	const u8 *reg_offset;
+	const u32 *reg_offset;
 	u32 spm_cfg;
 	u32 spm_dly;
 	u32 pmic_dly;
@@ -67,7 +67,7 @@ struct spm_driver_data {
 	const struct spm_reg_data *reg_data;
 };
 
-static const u8 spm_reg_offset_v2_1[SPM_REG_NR] = {
+static const u32 spm_reg_offset_v2_1[SPM_REG_NR] = {
 	[SPM_REG_CFG]		= 0x08,
 	[SPM_REG_SPM_CTL]	= 0x30,
 	[SPM_REG_DLY]		= 0x34,
@@ -86,7 +86,7 @@ static const struct spm_reg_data spm_reg_8974_8084_cpu  = {
 	.start_index[PM_SLEEP_MODE_SPC] = 3,
 };
 
-static const u8 spm_reg_offset_v1_1[SPM_REG_NR] = {
+static const u32 spm_reg_offset_v1_1[SPM_REG_NR] = {
 	[SPM_REG_CFG]		= 0x08,
 	[SPM_REG_SPM_CTL]	= 0x20,
 	[SPM_REG_PMIC_DLY]	= 0x24,

--- a/drivers/soc/qcom/spm.c
+++ b/drivers/soc/qcom/spm.c
@@ -56,6 +56,7 @@ struct spm_reg_data {
 	const u32 *reg_offset;
 	u32 spm_cfg;
 	u32 spm_dly;
+	u32 spm_ctl;
 	u32 pmic_dly;
 	u32 pmic_data[MAX_PMIC_DATA];
 	u8 seq[MAX_SEQ_DATA];
@@ -106,6 +107,28 @@ static const struct spm_reg_data spm_reg_8064_cpu = {
 		0x10, 0x54, 0x30, 0x0C, 0x24, 0x30, 0x0F },
 	.start_index[PM_SLEEP_MODE_STBY] = 0,
 	.start_index[PM_SLEEP_MODE_SPC] = 2,
+};
+
+static const u32 spm_reg_offset_v3_0[SPM_REG_NR] = {
+	[SPM_REG_CFG]		= 0x08,
+	[SPM_REG_SPM_CTL]	= 0x30,
+	[SPM_REG_DLY]		= 0x34,
+	[SPM_REG_PMIC_DATA_0]	= 0x40,
+	[SPM_REG_PMIC_DATA_1]	= 0x44,
+	[SPM_REG_SEQ_ENTRY]	= 0x400,
+};
+
+/* SPM register data for 8916 */
+static const struct spm_reg_data spm_reg_8916_cpu = {
+	.reg_offset = spm_reg_offset_v3_0,
+	.spm_cfg = 0x1,
+	.spm_ctl = 0xE,
+	.spm_dly = 0x3C102800,
+	.seq = { 0x60, 0x03, 0x60, 0x0B, 0x0F, 0x20, 0x10, 0x80, 0x30, 0x90,
+		0x5B, 0x60, 0x03, 0x60, 0x3B, 0x76, 0x76, 0x0B, 0x94, 0x5B,
+		0x80, 0x10, 0x26, 0x30, 0x0F },
+	.start_index[PM_SLEEP_MODE_STBY] = 0,
+	.start_index[PM_SLEEP_MODE_SPC] = 5,
 };
 
 static DEFINE_PER_CPU(struct spm_driver_data *, cpu_spm_drv);
@@ -320,6 +343,8 @@ static const struct of_device_id spm_match_table[] = {
 	  .data = &spm_reg_8974_8084_cpu },
 	{ .compatible = "qcom,apq8064-saw2-v1.1-cpu",
 	  .data = &spm_reg_8064_cpu },
+	{ .compatible = "qcom,msm8916-saw2-v3.0-cpu",
+	  .data = &spm_reg_8916_cpu },
 	{ },
 };
 
@@ -364,7 +389,8 @@ static int spm_dev_probe(struct platform_device *pdev)
 				drv->reg_data->pmic_data[0]);
 	spm_register_write(drv, SPM_REG_PMIC_DATA_1,
 				drv->reg_data->pmic_data[1]);
-
+	spm_register_write(drv, SPM_REG_SPM_CTL,
+				drv->reg_data->spm_ctl);
 	/* Set up Standby as the default low power mode */
 	spm_set_low_power_mode(drv, PM_SLEEP_MODE_STBY);
 


### PR DESCRIPTION
Mostly from: https://lore.kernel.org/linux-arm-msm/1429041520-6720-1-git-send-email-galak@codeaurora.org/

The file name `qcom-special-cpu-ops-dont-copy-this.c` is not from me, it was like this in the original patch. :D

```
[    0.152574] smp: Bringing up secondary CPUs ...
[    0.184940] Detected VIPT I-cache on CPU1
[    0.184991] CPU1: Booted secondary processor 0x0000000001 [0x410fd030]
[    0.216980] Detected VIPT I-cache on CPU2
[    0.217023] CPU2: Booted secondary processor 0x0000000002 [0x410fd030]
[    0.249043] Detected VIPT I-cache on CPU3
[    0.249081] CPU3: Booted secondary processor 0x0000000003 [0x410fd030]
[    0.249169] smp: Brought up 1 node, 4 CPUs
[    0.279591] SMP: Total of 4 processors activated.
```