### PR TITLE
Sound

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-pins.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-pins.dtsi
@@ -545,7 +545,7 @@
 				pins = "gpio63", "gpio64", "gpio65", "gpio66",
 				       "gpio67", "gpio68";
 				drive-strength = <2>;
-				bias-disable;
+				bias-pull-down;
 			};
 		};
 	};

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-a2015-common-pins.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-a2015-common-pins.dtsi
@@ -38,4 +38,16 @@
 			bias-disable;
 		};
 	};
+
+	jack_default: jack_default {
+		pinmux {
+			function = "gpio";
+			pins = "gpio110";
+		};
+		pinconf {
+			pins = "gpio110";
+			drive-strength = <2>;
+			bias-disable;
+		};
+	};
 };

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-a2015-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-a2015-common.dtsi
@@ -347,4 +347,15 @@
 			};
 		};
 	};
+	pm8916@1 {
+		codec@f000 {
+			jack-gpios = <&msmgpio 110 GPIO_ACTIVE_LOW>;
+			qcom,micbias-lvl = <2800>;
+			qcom,mbhc-vthreshold-low = <75 150 237 450 500>;
+			qcom,mbhc-vthreshold-high = <75 150 237 450 500>;
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&jack_default>;
+		};
+	};
 };

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-a2015-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-a2015-common.dtsi
@@ -7,6 +7,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/sound/apq8016-lpass.h>
 
 / {
 	aliases {
@@ -132,6 +133,46 @@
 					extcon = <&muic>;
 					v1p8-supply = <&pm8916_l7>;
 					v3p3-supply = <&pm8916_l13>;
+				};
+			};
+		};
+
+		lpass@7708000 {
+			status = "okay";
+		};
+
+		sound {
+			compatible = "qcom,apq8016-sbc-sndcard";
+			reg = <0x07702000 0x4>, <0x07702004 0x4>;
+			reg-names = "mic-iomux", "spkr-iomux";
+
+			pinctrl-names = "default", "sleep";
+			pinctrl-0 = <&cdc_pdm_lines_act>;
+			pinctrl-1 = <&cdc_pdm_lines_sus>;
+
+			qcom,model = "msm8916-samsung-a2015";
+			qcom,audio-routing =
+				"AMIC1", "MIC BIAS External1",
+				"AMIC2", "MIC BIAS Internal2",
+				"AMIC3", "MIC BIAS External1";
+
+			internal-codec-playback-dai-link@0 {
+				link-name = "WCD";
+				cpu {
+					sound-dai = <&lpass MI2S_PRIMARY>;
+				};
+				codec {
+					sound-dai = <&lpass_codec 0>, <&wcd_codec 0>;
+				};
+			};
+
+			internal-codec-capture-dai-link@0 {
+				link-name = "WCD-Capture";
+				cpu {
+					sound-dai = <&lpass MI2S_TERTIARY>;
+				};
+				codec {
+					sound-dai = <&lpass_codec 1>, <&wcd_codec 1>;
 				};
 			};
 		};

--- a/sound/soc/codecs/msm8916-wcd-analog.c
+++ b/sound/soc/codecs/msm8916-wcd-analog.c
@@ -306,7 +306,7 @@ struct pm8916_wcd_analog_priv {
 };
 
 static const char *const adc2_mux_text[] = { "ZERO", "INP2", "INP3" };
-static const char *const rdac2_mux_text[] = { "ZERO", "RX2", "RX1" };
+static const char *const rdac2_mux_text[] = { "RX1", "RX2" };
 static const char *const hph_text[] = { "ZERO", "Switch", };
 
 static const struct soc_enum hph_enum = SOC_ENUM_SINGLE_VIRT(
@@ -321,7 +321,7 @@ static const struct soc_enum adc2_enum = SOC_ENUM_SINGLE_VIRT(
 
 /* RDAC2 MUX */
 static const struct soc_enum rdac2_mux_enum = SOC_ENUM_SINGLE(
-			CDC_D_CDC_CONN_HPHR_DAC_CTL, 0, 3, rdac2_mux_text);
+			CDC_D_CDC_CONN_HPHR_DAC_CTL, 0, 2, rdac2_mux_text);
 
 static const struct snd_kcontrol_new spkr_switch[] = {
 	SOC_DAPM_SINGLE("Switch", CDC_A_SPKR_DAC_CTL, 7, 1, 0)

--- a/sound/soc/codecs/msm8916-wcd-analog.c
+++ b/sound/soc/codecs/msm8916-wcd-analog.c
@@ -11,6 +11,7 @@
 #include <linux/of.h>
 #include <linux/platform_device.h>
 #include <linux/regmap.h>
+#include <linux/gpio/consumer.h>
 #include <sound/soc.h>
 #include <sound/pcm.h>
 #include <sound/pcm_params.h>
@@ -298,6 +299,7 @@ struct pm8916_wcd_analog_priv {
 	struct snd_soc_component *component;
 	struct regulator_bulk_data supplies[ARRAY_SIZE(supply_names)];
 	struct snd_soc_jack *jack;
+	struct snd_soc_jack_gpio jack_gpio;
 	bool hphl_jack_type_normally_open;
 	bool gnd_jack_type_normally_open;
 	/* Voltage threshold when internal current source of 100uA is used */
@@ -504,7 +506,7 @@ static void pm8916_wcd_setup_mbhc(struct pm8916_wcd_analog_priv *wcd)
 	struct snd_soc_component *component = wcd->component;
 	bool micbias_enabled = false;
 	u32 plug_type = 0;
-	u32 int_en_mask;
+	u32 int_en_mask = 0;
 
 	snd_soc_component_write(component, CDC_A_MBHC_DET_CTL_1,
 		      CDC_A_MBHC_DET_CTL_L_DET_EN |
@@ -539,7 +541,8 @@ static void pm8916_wcd_setup_mbhc(struct pm8916_wcd_analog_priv *wcd)
 
 	pm8916_mbhc_configure_bias(wcd, micbias_enabled);
 
-	int_en_mask = MBHC_SWITCH_INT;
+	if (!wcd->jack_gpio.report)
+		int_en_mask |= MBHC_SWITCH_INT;
 	if (wcd->mbhc_btn_enabled)
 		int_en_mask |= MBHC_BUTTON_PRESS_DET | MBHC_BUTTON_RELEASE_DET;
 
@@ -993,6 +996,22 @@ static int pm8916_wcd_analog_set_jack(struct snd_soc_component *component,
 {
 	struct pm8916_wcd_analog_priv *wcd = snd_soc_component_get_drvdata(component);
 
+	if (wcd->jack_gpio.report && wcd->jack != jack) {
+		int ret;
+
+		if (wcd->jack)
+			snd_soc_jack_free_gpios(wcd->jack, 1, &wcd->jack_gpio);
+
+		if (jack) {
+			ret = snd_soc_jack_add_gpiods(component->dev, jack,
+						      1, &wcd->jack_gpio);
+			if (ret)
+				dev_err(component->dev,
+					"Failed to add GPIO to jack: %d\n",
+					ret);
+		}
+	}
+
 	wcd->jack = jack;
 
 	return 0;
@@ -1054,15 +1073,10 @@ static irqreturn_t mbhc_btn_press_irq_handler(int irq, void *arg)
 	return IRQ_HANDLED;
 }
 
-static irqreturn_t pm8916_mbhc_switch_irq_handler(int irq, void *arg)
+static int pm8916_wcd_analog_switch_check(struct pm8916_wcd_analog_priv *priv, bool ins)
 {
-	struct pm8916_wcd_analog_priv *priv = arg;
 	struct snd_soc_component *component = priv->component;
-	bool ins = false;
-
-	if (snd_soc_component_read32(component, CDC_A_MBHC_DET_CTL_1) &
-				CDC_A_MBHC_DET_CTL_MECH_DET_TYPE_MASK)
-		ins = true;
+	int report;
 
 	/* Set the detection type appropriately */
 	snd_soc_component_update_bits(component, CDC_A_MBHC_DET_CTL_1,
@@ -1086,21 +1100,44 @@ static irqreturn_t pm8916_mbhc_switch_irq_handler(int irq, void *arg)
 		 * a headset.
 		 */
 		if (priv->mbhc_btn0_released)
-			snd_soc_jack_report(priv->jack,
-					    SND_JACK_HEADSET, hs_jack_mask);
+			report = SND_JACK_HEADSET;
 		else
-			snd_soc_jack_report(priv->jack,
-					    SND_JACK_HEADPHONE, hs_jack_mask);
+			report = SND_JACK_HEADPHONE;
 
 		priv->detect_accessory_type = false;
 
 	} else { /* removal */
-		snd_soc_jack_report(priv->jack, 0, hs_jack_mask);
+		report = 0;
 		priv->detect_accessory_type = true;
 		priv->mbhc_btn0_released = false;
 	}
 
+	return report;
+}
+
+static irqreturn_t pm8916_mbhc_switch_irq_handler(int irq, void *arg)
+{
+	struct pm8916_wcd_analog_priv *priv = arg;
+	struct snd_soc_component *component = priv->component;
+	bool ins = false;
+	int report;
+
+	if (snd_soc_component_read32(component, CDC_A_MBHC_DET_CTL_1) &
+				CDC_A_MBHC_DET_CTL_MECH_DET_TYPE_MASK)
+		ins = true;
+
+	report = pm8916_wcd_analog_switch_check(priv, ins);
+	snd_soc_jack_report(priv->jack, report, btn_mask);
+
 	return IRQ_HANDLED;
+}
+
+static int pm8916_wcd_analog_jack_status_check(void *data)
+{
+	struct pm8916_wcd_analog_priv *wcd = data;
+
+	bool ins = gpiod_get_value_cansleep(wcd->jack_gpio.desc);
+	return pm8916_wcd_analog_switch_check(wcd, ins);
 }
 
 static struct snd_soc_dai_driver pm8916_wcd_analog_dai[] = {
@@ -1234,6 +1271,14 @@ static int pm8916_wcd_analog_spmi_probe(struct platform_device *pdev)
 		return ret;
 	}
 
+	if (gpiod_count(dev, "jack") > 0) {
+		priv->jack_gpio.name = "jack";
+		priv->jack_gpio.report = hs_jack_mask;
+		priv->jack_gpio.debounce_time = 100;
+		priv->jack_gpio.jack_status_check =
+			pm8916_wcd_analog_jack_status_check;
+		priv->jack_gpio.data = priv;
+	} else {
 	irq = platform_get_irq_byname(pdev, "mbhc_switch_int");
 	if (irq < 0) {
 		dev_err(dev, "failed to get mbhc switch irq\n");
@@ -1247,6 +1292,7 @@ static int pm8916_wcd_analog_spmi_probe(struct platform_device *pdev)
 			       "mbhc switch irq", priv);
 	if (ret)
 		dev_err(dev, "cannot request mbhc switch irq\n");
+	}
 
 	if (priv->mbhc_btn_enabled) {
 		irq = platform_get_irq_byname(pdev, "mbhc_but_press_det");


### PR DESCRIPTION
- [x] Decide what to do with A3U weirdness (ignore)
  - [qcom,msm-micbias1-ext-cap](https://github.com/msm8916-mainline/android_kernel_qcom_msm8916/blame/SM-A300FU/arch/arm/boot/dts/samsung/msm8916/msm8916-sec-a3u-eur-r01.dtsi#L286) exists only in MM version of A3U
  - [Mainline also has that property](https://github.com/msm8916-mainline/linux/blob/a6e3b4e9b81b7d45998d4e01bc615f8b7d95b82f/Documentation/devicetree/bindings/sound/qcom%2Cmsm8916-wcd-analog.txt#L50-L51)
  - Cannot find anything related in the schematic
  - I'd not add it, must have been working without for previous Android versions and I couldn't justify why it's there...

I added `qcom,micbias-lvl = <2800>`. This doesn't exist on DB410c, but [downstream suggests that this is what Samsung is using](https://github.com/msm8916-mainline/android_kernel_qcom_msm8916/blob/3b09f23015d2f0949d49fb81ea1f43c63a8be503/sound/soc/codecs/msm8x16-wcd.c#L5063).
  
Test with new UCM files in [soc-qcom-msm8916-alsa-ucm](https://gitlab.com/lambdadroid/pmaports/commit/a6e831980fdbf689ad7b86477c8fd74b14531e3b):
```
$ alsaucm -i -c msm8916-samsung-a2015
set _verb HiFi
set _enadev A
[test...]
$ alsaucm -i -c msm8916-samsung-a2015
set _enadev A
set _disdev A
set _enadev B
```

- **Playback**
  - [x] `Earpiece`
  - [x] `Headphones`
- **Capture**
  ```
  $ arecord -f dat -Dplughw:0,1 test.wav
  $ aplay test.wav
  ```
  - [x] `PrimaryMic`
  - [x] `SecondaryMic`
  - [ ] `HeadsetMic`
- **Jack Detection** (using `evtest`)
  - [x] Headphones/Headset
  - [x] Button presses

(:heavy_check_mark: All working fine on SM-A500FU)