### PR TITLE
arm64: dts: qcom: apq8016-samsung-gt510wifi: Enable SMP without PSCI

### DIFF
--- a/arch/arm64/boot/dts/qcom/apq8016-samsung-gt510wifi.dts
+++ b/arch/arm64/boot/dts/qcom/apq8016-samsung-gt510wifi.dts
@@ -4,6 +4,7 @@
 
 #include "msm8916.dtsi"
 #include "pm8916.dtsi"
+#include "msm8916-no-psci-sad-face.dtsi"
 #include <dt-bindings/gpio/gpio.h>
 
 / {


### PR DESCRIPTION
Enables all 4 cores on boot without PSCI using the dtsi already in the repo.