### PR TITLE
arm64: dts: qcom: apq8016-samsung-gt510wifi: Enable wcnss

### DIFF
--- a/arch/arm64/boot/dts/qcom/apq8016-samsung-gt510wifi.dts
+++ b/arch/arm64/boot/dts/qcom/apq8016-samsung-gt510wifi.dts
@@ -69,6 +69,14 @@
 			};
 		};
 
+		wcnss@a21b000 {
+			status = "okay";
+
+			iris {
+				compatible = "qcom,wcn3680";
+			};
+		};
+
 		/*
 		 * Attempting to enable these devices causes a "synchronous
 		 * external abort". Suspected cause is that the debug power


### PR DESCRIPTION
Enable WiFi and BT on this device.
- WiFi: works, but only on 2.4GHz
- BT: pairs, connects, but only briefly (needs more testing)