### PR TITLE
arm64: dts: qcom: msm8916-motorola-harpia: Enable WCNSS

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-motorola-harpia.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-motorola-harpia.dts
@@ -67,6 +67,10 @@
 			};
 		};
 
+		wcnss@a21b000 {
+			status = "okay";
+		};
+
 		/*
 		 * Attempting to enable these devices causes a "synchronous
 		 * external abort". Suspected cause is that the debug power


### PR DESCRIPTION
Confirmed both Wi-Fi and Bluetooth both functional on my Moto G4 Play.