### PR TITLE
gt510wifi: Add audio functionality

### DIFF
--- a/arch/arm64/boot/dts/qcom/apq8016-samsung-gt510wifi.dts
+++ b/arch/arm64/boot/dts/qcom/apq8016-samsung-gt510wifi.dts
@@ -8,6 +8,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/sound/apq8016-lpass.h>
 
 / {
 	model = "Samsung Galaxy Tab A 9.7 WiFi (2015) (SM-T550)";
@@ -59,6 +60,46 @@
 			pinctrl-names = "default", "sleep";
 			pinctrl-0 = <&blsp1_uart2_default>;
 			pinctrl-1 = <&blsp1_uart2_sleep>;
+		};
+
+		lpass@7708000 {
+			status = "okay";
+		};
+
+		sound {
+			compatible = "qcom,apq8016-sbc-sndcard";
+			reg = <0x07702000 0x4>, <0x07702004 0x4>;
+			reg-names = "mic-iomux", "spkr-iomux";
+
+			pinctrl-names = "default", "sleep";
+			pinctrl-0 = <&cdc_pdm_lines_act>;
+			pinctrl-1 = <&cdc_pdm_lines_sus>;
+
+			qcom,model = "msm8916";
+			qcom,audio-routing =
+				"AMIC1", "MIC BIAS External1",
+				"AMIC2", "MIC BIAS Internal2",
+				"AMIC3", "MIC BIAS External1";
+
+			internal-codec-playback-dai-link@0 {
+				link-name = "WCD";
+				cpu {
+					sound-dai = <&lpass MI2S_PRIMARY>;
+				};
+				codec {
+					sound-dai = <&lpass_codec 0>, <&wcd_codec 0>;
+				};
+			};
+
+			internal-codec-capture-dai-link@0 {
+				link-name = "WCD-Capture";
+				cpu {
+					sound-dai = <&lpass MI2S_TERTIARY>;
+				};
+				codec {
+					sound-dai = <&lpass_codec 1>, <&wcd_codec 1>;
+				};
+			};
 		};
 
 		usb@78d9000 {

--- a/arch/arm64/boot/dts/qcom/apq8016-samsung-gt510wifi.dts
+++ b/arch/arm64/boot/dts/qcom/apq8016-samsung-gt510wifi.dts
@@ -75,7 +75,7 @@
 			pinctrl-0 = <&cdc_pdm_lines_act>;
 			pinctrl-1 = <&cdc_pdm_lines_sus>;
 
-			qcom,model = "msm8916";
+			qcom,model = "msm8916"; // FIXME
 			qcom,audio-routing =
 				"AMIC1", "MIC BIAS External1",
 				"AMIC2", "MIC BIAS Internal2",
@@ -325,6 +325,18 @@
 			};
 		};
 	};
+
+	pm8916@1 {
+		codec@f000 {
+			jack-gpios = <&msmgpio 110 GPIO_ACTIVE_LOW>;
+			qcom,micbias-lvl = <2800>;
+			qcom,mbhc-vtreshold-low = <75 150 237 450 500>;
+			qcom,mbhc-vtreshold-high = <75 150 237 450 500>;
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&jack_default>;
+		};
+	};
 };
 
 &smd_rpm_regulators {
@@ -472,6 +484,18 @@
 		};
 		pinconf {
 			pins = "gpio52";
+			drive-strength = <2>;
+			bias-disable;
+		};
+	};
+
+	jack_default: jack_default {
+		pinmux {
+			function = "gpio";
+			pins = "gpio110";
+		};
+		pinconf {
+			pins = "gpio110";
 			drive-strength = <2>;
 			bias-disable;
 		};


### PR DESCRIPTION
See #45 

Tested since then:
- Microphones

Untested:
- Speaker (supposedly uses an amp, may or may not work by default)