### PR TITLE
arm64: dts: qcom: apq8016-samsung-matissevewifi: add WIFI/BT support

### DIFF
--- a/arch/arm64/boot/dts/qcom/apq8016-samsung-matissevewifi.dts
+++ b/arch/arm64/boot/dts/qcom/apq8016-samsung-matissevewifi.dts
@@ -77,6 +77,14 @@
 			};
 		};
 
+		wcnss@a21b000 {
+			status = "okay";
+
+			iris {
+				compatible = "qcom,wcn3680";
+			};
+		};
+
 		/*
 		 * Attempting to enable these devices causes a "synchronous
 		 * external abort". Suspected cause is that the debug power


### PR DESCRIPTION

[matissevewifi_dmesg.log](https://github.com/msm8916-mainline/linux/files/4302163/matissevewifi_dmesg.log)
