### PR TITLE
arm64: dts: qcom: Add WiFi/BT support for BQ Aquaris X5 Cyanogen Edition

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-bq-paella.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-bq-paella.dts
@@ -68,6 +68,10 @@
 				};
 			};
 		};
+
+		wcnss@a21b000 {
+			status = "okay";
+		};
 	};
 
 	usb_id: usb-id {


### PR DESCRIPTION
Added WiFi and BlueTooth support