### PR TITLE
arm64: dts: qcom: msm8916-bq-paella: Add volume buttons

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-bq-paella.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-bq-paella.dts
@@ -120,6 +120,21 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&ts_vcca_default>;
 	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&gpio_keys_default>;
+
+		label = "GPIO Buttons";
+
+		volume-up {
+			label = "Volume Up";
+			gpios = <&msmgpio 107 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_VOLUMEUP>;
+		};
+	};
 };
 
 &smd_rpm_regulators {
@@ -355,6 +370,18 @@
 			bias-disable;
 		};
 	};
+
+	gpio_keys_default: gpio_keys_default {
+		pinmux {
+			function = "gpio";
+			pins = "gpio107";
+		};
+		pinconf {
+			pins = "gpio107";
+			drive-strength = <2>;
+			bias-pull-up;
+		};
+	};
 };
 
 &pm8916_mpps {
@@ -370,6 +397,17 @@
 };
 
 &spmi_bus {
+	pm8916@0 {
+		pon@800 {
+			volume-down {
+				compatible = "qcom,pm8941-resin";
+				interrupts = <0x0 0x8 1 IRQ_TYPE_EDGE_BOTH>;
+				bias-pull-up;
+				linux,code = <KEY_VOLUMEDOWN>;
+			};
+		};
+	};
+
 	pm8916@1 {
 		pwm@bc00 {
 			status = "okay";


### PR DESCRIPTION
Volume buttons tested and working:
```
Event: time 1586628567.175091, type 1 (EV_KEY), code 114 (KEY_VOLUMEDOWN), value 1
Event: time 1586628567.175091, -------------- SYN_REPORT ------------
Event: time 1586628567.289923, type 1 (EV_KEY), code 114 (KEY_VOLUMEDOWN), value 0
Event: time 1586628567.289923, -------------- SYN_REPORT ------------
```
```
Event: time 1586628576.884556, type 1 (EV_KEY), code 115 (KEY_VOLUMEUP), value 1
Event: time 1586628576.884556, -------------- SYN_REPORT ------------
Event: time 1586628577.048528, type 1 (EV_KEY), code 115 (KEY_VOLUMEUP), value 0
Event: time 1586628577.048528, -------------- SYN_REPORT ------------
```