### PR TITLE
oppo-a51f: add vibration

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-oppo-a51f.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-oppo-a51f.dts
@@ -157,6 +157,10 @@
 	status = "okay";
 };
 
+&pm8916_vib {
+	status = "okay";
+};
+
 &pronto {
 	status = "okay";
 };


### PR DESCRIPTION
need to "apk add linuxconsoletools"

and use "fftest /dev/input/event4"