### PR TITLE
arm64: dts: qcom: oppo-a51f: add bq24190 feature [WIP]

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-oppo-a51f.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-oppo-a51f.dts
@@ -101,6 +101,32 @@
 	};
 };
 
+&blsp_i2c4 {
+	status = "okay";
+
+	bat: battery@31 {
+		compatible = "simple-battery";
+		reg = <0x31>;
+		/*usbin-switch-gpio = <0x4c 0x04 GPIO_ACTIVE_HIGH>;*/
+		interrupts = <&msmgpio 31 GPIO_ACTIVE_HIGH>;
+		precharge-current-microamp = <256000>;
+		charge-term-current-microamp = <128000>;
+		// etc.
+	};
+
+	bq24190: charger@6a {
+		compatible = "ti,bq24190";
+		reg = <0x6a>;
+		interrupts-extended = <&msmgpio 62 GPIO_ACTIVE_HIGH>;
+		vio-supply = <&pm8916_l5>;
+		monitored-battery = <&bat>;
+		ti,system-minimum-microvolt = <3200000>;
+
+		/*usb_otg_vbus: usb-otg-vbus { };*/
+	};
+
+};
+
 &blsp_i2c5 {
 	status = "okay";
 

--- a/arch/arm64/boot/dts/qcom/msm8916-oppo-a51f.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-oppo-a51f.dts
@@ -115,7 +115,7 @@
 	};
 
 	bq24190: charger@6a {
-		compatible = "ti,bq24190";
+		compatible = "ti,bq24196";
 		reg = <0x6a>;
 		interrupts-extended = <&msmgpio 62 GPIO_ACTIVE_HIGH>;
 		vio-supply = <&pm8916_l5>;


### PR DESCRIPTION
on my phone model, it use bq24196, but in manual seems it can use bq24190 for capable, but for battery I still can't detect it under dmesg, does any method to check that battery is existed?

P.S. seems my battery need a resist to identify which vendor provide... atl use 47kohm, sony use 200kohm...
My variant is : batterydata_read_data: oppo_4v35_2420mah_sony loaded