### PR TITLE
arm64: dts: qcom: msm8916-bq-paella: Fix touchscreen

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-bq-paella.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-bq-paella.dts
@@ -150,7 +150,7 @@
 		reg = <0x48>;
 
 		interrupt-parent = <&msmgpio>;
-		interrupts = <13 IRQ_TYPE_EDGE_FALLING>;
+		interrupts = <13 IRQ_TYPE_LEVEL_LOW>;
 
 		reset-gpio = <&msmgpio 12 GPIO_ACTIVE_HIGH>;
 


### PR DESCRIPTION
Whenever a touch event is available, the touchscreen changes the GPIO
for the IRQ from high -> low (a falling edge). The GPIO is changed back
from low -> high once the touch event has been read with
HX852_READ_ALL_EVENTS.

At least on the BQ models, the touchscreen seems to send an empty
touch event after initial power up, so the GPIO switches to "low".
This is before the IRQ is enabled, so hx852_interrupt() is not triggered.

This means that we don't read the event from the controller
(HX852_READ_ALL_EVENTS) and therefore the GPIO does not change back
from low -> high. This is problematic because hx852_interrupt()
is only triggered when the GPIO switches from high -> low.
It is not triggered when the IRQ stays on low forever.

In other words, we will never get any further touch events from the
controller. :(

This can be avoided by making the IRQ level triggered (as on downstream).
Now, hx852_interrupt() is repeatedly called as long as the IRQ stays
low. This means that we read the pending touch event as soon as the IRQ
is enabled and then receive all further IRQs as well. Yay!

Cc: @JonnyMe 