### PR TITLE
oppo-a51f: add sound support 

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-oppo-a51f.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-oppo-a51f.dts
@@ -5,6 +5,7 @@
 #include "msm8916-pm8916.dtsi"
 #include "msm8916-no-psci.dtsi"
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/sound/apq8016-lpass.h>
 
 / {
 	model = "Oppo Mirror 5s (A51f)";
@@ -93,11 +94,36 @@
 		pinctrl-0 = <&sd_vmmc_en_default>;
 	};
 
+	speaker_amp: audio-amplifier {
+		compatible = "simple-audio-amplifier";
+		VCC-supply = <&reg_speaker_boost>;
+		enable-gpios = <&msmgpio 120 GPIO_ACTIVE_HIGH>;
+		sound-name-prefix = "Speaker Amp";
+
+		gpios = <&msmgpio 120 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		pinctrl-names = "default";
+		pinctrl-0 = <&speaker_amp_default>;
+
+	};
+
 	usb_id: usb-id {
 		compatible = "linux,extcon-usb-gpio";
 		id-gpio = <&msmgpio 110 GPIO_ACTIVE_HIGH>;
 		pinctrl-names = "default";
 		pinctrl-0 = <&usb_id_default>;
+	};
+
+	reg_speaker_boost: regulator-speaker-boost {
+		compatible = "regulator-fixed";
+		regulator-name = "yda145-amp";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpios = <&msmgpio 118 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+		pinctrl-names = "default";
+		pinctrl-0 = <&speaker_boost_default>;
 	};
 };
 
@@ -236,6 +262,10 @@
 	qcom,dsi-phy-regulator-ldo-mode;
 };
 
+&lpass {
+	status = "okay";
+};
+
 &usb {
 	status = "okay";
 	extcon = <&usb_id>, <&usb_id>;
@@ -243,6 +273,53 @@
 
 &usb_hs_phy {
 	extcon = <&usb_id>;
+};
+
+&sound {
+	status = "okay";
+
+	pinctrl-names = "default", "sleep";
+
+	pinctrl-0 = <&cdc_pdm_lines_act>;
+	pinctrl-1 = <&cdc_pdm_lines_sus>;
+
+	model = "oppo-a51f";
+	audio-routing =
+			"Speaker Amp INL", "HPH_L_EXT",
+			"Speaker Amp INR", "HPH_L_EXT",
+			"AMIC1", "MIC BIAS External1",
+			"AMIC2", "MIC BIAS External2";
+
+	aux-devs = <&speaker_amp>;
+
+	dai-link-primary {
+		link-name = "Primary MI2S";
+		cpu {
+			sound-dai = <&lpass MI2S_PRIMARY>;
+		};
+		codec {
+			sound-dai = <&lpass_codec 0>, <&wcd_codec 0>;
+		};
+	};
+
+	dai-link-tertiary {
+		link-name = "Tertiary MI2S";
+		cpu {
+			sound-dai = <&lpass MI2S_TERTIARY>;
+		};
+		codec {
+			sound-dai = <&lpass_codec 1>, <&wcd_codec 1>;
+		};
+	};
+};
+
+&wcd_codec {
+	qcom,micbias1-ext-cap;
+	qcom,micbias2-ext-cap;
+	qcom,micbias-lvl = <2800>;
+	qcom,mbhc-vthreshold-low = <75 100 120 180 500>;
+	qcom,mbhc-vthreshold-high = <75 100 120 180 500>;
+	qcom,hphl-jack-type-normally-open;
 };
 
 &smd_rpm_regulators {
@@ -424,6 +501,22 @@
 
 	sd_vmmc_en_default: sd-vmmc-en-default {
 		pins = "gpio116";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	speaker_amp_default: speaker-amp-default {
+		pins = "gpio120";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	speaker_boost_default: speaker-boost-default {
+		pins = "gpio118";
 		function = "gpio";
 
 		drive-strength = <2>;


### PR DESCRIPTION
after discussion :
seems the earphone & speaker is left channel only, so set it to mono output.
and due to headphone (3.5" phonejack) with ts4621 which is custom PA from oppo, so it's less priority for add it now...