### PR TITLE
arm64: dts: qcom: msm8916-wingtech-wt86528: add touchscreen

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-wingtech-wt86528.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-wingtech-wt86528.dts
@@ -95,6 +95,29 @@
 	};
 };
 
+&blsp_i2c5 {
+	status = "okay";
+
+	touchscreen@38 {
+		/* actually FT5336 */
+		compatible = "edt,edt-ft5306";
+		reg = <0x38>;
+
+		interrupt-parent = <&msmgpio>;
+		interrupts = <13 IRQ_TYPE_EDGE_FALLING>;
+
+		vcc-supply = <&pm8916_l17>;
+
+		reset-gpios = <&msmgpio 12 GPIO_ACTIVE_LOW>;
+
+		touchscreen-size-x = <720>;
+		touchscreen-size-y = <1280>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&touchscreen_default>;
+	};
+};
+
 &blsp1_uart2 {
 	status = "okay";
 };
@@ -311,6 +334,22 @@
 
 			drive-strength = <2>;
 			bias-pull-down;
+		};
+	};
+
+	touchscreen_default: touchscreen-default {
+		pins = "gpio13";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-pull-up;
+
+		reset {
+			pins = "gpio12";
+			function = "gpio";
+
+			drive-strength = <2>;
+			bias-disable;
 		};
 	};
 


### PR DESCRIPTION
Every touch at under screen buttons (which are return, home, recent apps in android) leads to` type 1 (EV_KEY), code 330 (BTN_TOUCH), value 1` in evtest. otherwise it works