### PR TITLE
arm64: dts: qcom: msm8916-wingtech-wt86528: add sensors

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-wingtech-wt86528.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-wingtech-wt86528.dts
@@ -95,6 +95,36 @@
 	};
 };
 
+&blsp_i2c2 {
+	status = "okay";
+
+	imu@68 {
+		compatible = "invensense,mpu6880";
+		reg = <0x68>;
+
+		interrupt-parent = <&msmgpio>;
+		interrupts = <115 IRQ_TYPE_EDGE_RISING>;
+
+		vdd-supply = <&pm8916_l17>;
+		vddio-supply = <&pm8916_l6>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&imu_default>;
+
+		mount-matrix = "1",  "0", "0",
+			       "0", "-1", "0",
+			       "0",  "0", "1";
+	};
+
+	magnetometer@c {
+		compatible = "asahi-kasei,ak09911";
+		reg = <0x0c>;
+
+		vdd-supply = <&pm8916_l17>;
+		vid-supply = <&pm8916_l6>;
+	};
+};
+
 &blsp_i2c5 {
 	status = "okay";
 
@@ -314,6 +344,14 @@
 
 	gpio_leds_default: gpio-leds-default {
 		pins = "gpio16", "gpio17";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	imu_default: imu-default {
+		pins = "gpio115";
 		function = "gpio";
 
 		drive-strength = <2>;


### PR DESCRIPTION
elan-epl2182, akm09911 and fan54015 charger are no supported by mainline so imu is the only sensor supported.