### PR TITLE
arm64: dts: qcom: msm8916-asus-z00l: add sound

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-asus-z00l.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-asus-z00l.dts
@@ -6,6 +6,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/sound/apq8016-lpass.h>
 
 / {
 	model = "Asus Zenfone 2 Laser";
@@ -106,6 +107,10 @@
 	remote-endpoint = <&panel_in>;
 };
 
+&lpass {
+	status = "okay";
+};
+
 &pronto {
 	status = "okay";
 };
@@ -118,6 +123,40 @@
 	pinctrl-1 = <&sdc1_clk_off &sdc1_cmd_off &sdc1_data_off>;
 };
 
+&sound {
+	status = "okay";
+
+	pinctrl-names = "default", "sleep";
+	pinctrl-0 = <&cdc_pdm_lines_act>;
+	pinctrl-1 = <&cdc_pdm_lines_sus>;
+
+	model = "msm8916";
+	audio-routing =
+		"AMIC1", "MIC BIAS External1",
+		"AMIC2", "MIC BIAS Internal2",
+		"AMIC3", "MIC BIAS External1";
+
+	dai-link-primary {
+		link-name = "Primary MI2S";
+		cpu {
+			sound-dai = <&lpass MI2S_PRIMARY>;
+		};
+		codec {
+			sound-dai = <&lpass_codec 0>, <&wcd_codec 0>;
+		};
+	};
+
+	dai-link-tertiary {
+		link-name = "Tertiary MI2S";
+		cpu {
+			sound-dai = <&lpass MI2S_TERTIARY>;
+		};
+		codec {
+			sound-dai = <&lpass_codec 1>, <&wcd_codec 1>;
+		};
+	};
+};
+
 &usb {
 	status = "okay";
 	extcon = <&usb_id>, <&usb_id>;
@@ -125,6 +164,14 @@
 
 &usb_hs_phy {
 	extcon = <&usb_id>;
+};
+
+&wcd_codec {
+	qcom,micbias-lvl = <2800>;
+	qcom,mbhc-vthreshold-low = <75 150 237 450 500>;
+	qcom,mbhc-vthreshold-high = <75 150 237 450 500>;
+	qcom,micbias1-ext-cap;
+	qcom,hphl-jack-type-normally-open;
 };
 
 &smd_rpm_regulators {


### PR DESCRIPTION
Device tree for sound. Copied from Motorola Harpia Device tree.

What works,

 * Speaker
 * Headphone/Earphones
 * Primary/Secondary Microphones
 * Audio Jack Events.

<strike>What does not work,
 When headphone is plugged in, it does not change the output to headphone automatically. Is this a userland problem?(Does the same happen with Motorola Harpia). </strike> (It actually works, It's a userland problem in phosh)

Based the device tree on https://github.com/LineageOS/android_kernel_asus_msm8916/blob/1a45c63742b8c3253a38c2ff97b672918c88d8df/arch/arm/boot/dts/qcom/msm8916-mtp-ze550kl.dtsi#L230