### PR TITLE
ASoC: tfa9895: add dummy read when probing

### DIFF
--- a/sound/soc/codecs/tfa9895.c
+++ b/sound/soc/codecs/tfa9895.c
@@ -168,6 +168,9 @@ static int tfa9895_i2c_probe(struct i2c_client *i2c)
 	if (IS_ERR(regmap))
 		return PTR_ERR(regmap);
 
+	/* Dummy read to generate i2c clocks, required on some devices */
+	regmap_read(regmap, TFA98XX_REVISIONNUMBER, &val);
+
 	ret = regmap_read(regmap, TFA98XX_REVISIONNUMBER, &val);
 	if (ret) {
 		dev_err(dev, "failed to read revision number: %d\n", ret);


### PR DESCRIPTION
This is required on some devices to generate i2c clocks when accessing the amplifier for the first time.

Note:
Comment is based on the comment for msm8996 [here](https://github.com/commaai/android_kernel_comma_msm8996/blob/2bfa5cc327e32051d28236ee18a13debd805186f/drivers/comma/oneplus/sound/tfa98xx.c#L806-L810), I have no idea if it is accurate.. :) 