### PR TITLE
ASUS Zenfone 2 Laser (720p) Add SD Card Storage

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-asus-z00l.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-asus-z00l.dts
@@ -44,6 +44,21 @@
 		};
 	};
 
+	reg_sd_vmmc: regulator-sdcard-vmmc {
+		compatible = "regulator-fixed";
+		regulator-name = "sdcard-vmmc";
+		regulator-min-microvolt = <2950000>;
+		regulator-max-microvolt = <2950000>;
+
+		gpio = <&msmgpio 87 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+
+		startup-delay-us = <200>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&sd_vmmc_en_default>;
+	};
+
 	reserved-memory {
 		/delete-node/ wcnss@89300000;
 		/delete-node/ venus@89900000;
@@ -143,6 +158,16 @@
 	pinctrl-names = "default", "sleep";
 	pinctrl-0 = <&sdc1_clk_on &sdc1_cmd_on &sdc1_data_on>;
 	pinctrl-1 = <&sdc1_clk_off &sdc1_cmd_off &sdc1_data_off>;
+};
+
+&sdhc_2 {
+	status = "okay";
+	vmmc-supply = <&reg_sd_vmmc>;
+
+	pinctrl-names = "default", "sleep";
+	pinctrl-0 = <&sdc2_clk_on &sdc2_cmd_on &sdc2_data_on &sdc2_cd_on>;
+	pinctrl-1 = <&sdc2_clk_off &sdc2_cmd_off &sdc2_data_off &sdc2_cd_off>;
+	cd-gpios = <&msmgpio 38 GPIO_ACTIVE_LOW>;
 };
 
 &sound {
@@ -331,6 +356,14 @@
 			drive-strength = <2>;
 			bias-pull-down;
 		};
+	};
+
+	sd_vmmc_en_default: sd-vmmc-en-default {
+		pins = "gpio87";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
 	};
 
 	touchscreen_default: touchscreen-default {


### PR DESCRIPTION
The SD Card works well with this changes and I was able to sort of dual boot Android and postmarketOS with the sd card.