### PR TITLE
ASUS Zenfone 2 Laser (Z00L) Add Sensors

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-asus-z00l.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-asus-z00l.dts
@@ -88,6 +88,41 @@
 	};
 };
 
+&blsp_i2c2 {
+	status = "okay";
+
+	magnetometer@c {
+		compatible = "asahi-kasei,ak09911";
+		reg = <0x0c>;
+
+		vdd-supply = <&pm8916_l8>;
+		vid-supply = <&pm8916_l6>;
+
+		reset-gpios = <&msmgpio 112 GPIO_ACTIVE_LOW>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&mag_reset_default>;
+	};
+
+	imu@68 {
+		compatible = "invensense,mpu6515";
+		reg = <0x68>;
+
+		interrupt-parent = <&msmgpio>;
+		interrupts = <36 IRQ_TYPE_EDGE_RISING>;
+
+		vdd-supply = <&pm8916_l17>;
+		vddio-supply = <&pm8916_l6>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&imu_default>;
+
+		mount-matrix = "1",  "0", "0",
+			       "0", "-1", "0",
+			       "0",  "0", "1";
+	};
+};
+
 &blsp_i2c5 {
 	status = "okay";
 
@@ -333,8 +368,24 @@
 		bias-pull-up;
 	};
 
+	imu_default: imu-default {
+		pins = "gpio36";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
 	lcd_bl_en_default: lcd-bl-en-default {
 		pins = "gpio21";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	mag_reset_default: mag-reset-default {
+		pins = "gpio112";
 		function = "gpio";
 
 		drive-strength = <2>;


### PR DESCRIPTION
Add support for Gyroscope, Accelerometer and Magnetometer. Downstream device tree reference on these nodes is [here](https://github.com/LineageOS/android_kernel_asus_msm8916/blob/1a45c63742b8c3253a38c2ff97b672918c88d8df/arch/arm/boot/dts/qcom/msm8916-mtp-ze550kl.dtsi#L159).