### PR TITLE
ASoC: tfa9895: Add support for TFA9897

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-alcatel-idol347.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-alcatel-idol347.dts
@@ -7,6 +7,7 @@
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/pinctrl/qcom,pmic-mpp.h>
+#include <dt-bindings/sound/apq8016-lpass.h>
 
 / {
 	model = "Alcatel OneTouch Idol 3 (4.7)";
@@ -54,6 +55,26 @@
 
 &blsp1_uart2 {
 	status = "okay";
+};
+
+&blsp_i2c3 {
+	status = "okay";
+
+	speaker_codec_top: audio-codec@34 {
+		compatible = "nxp,tfa9897";
+		reg = <0x34>;
+		vdd-supply = <&pm8916_l6>;
+		#sound-dai-cells = <0>;
+		sound-name-prefix = "Speaker Top";
+	};
+
+	speaker_codec_bottom: audio-codec@36 {
+		compatible = "nxp,tfa9897";
+		reg = <0x36>;
+		vdd-supply = <&pm8916_l6>;
+		#sound-dai-cells = <0>;
+		sound-name-prefix = "Speaker Bottom";
+	};
 };
 
 &blsp_i2c4 {
@@ -178,6 +199,10 @@
 	qcom,dsi-phy-regulator-ldo-mode;
 };
 
+&lpass {
+	status = "okay";
+};
+
 &pm8916_pwm {
 	status = "okay";
 	pinctrl-names = "default";
@@ -215,6 +240,50 @@
 	cd-gpios = <&msmgpio 38 GPIO_ACTIVE_LOW>;
 };
 
+&sound {
+	status = "okay";
+
+	pinctrl-names = "default", "sleep";
+	pinctrl-0 = <&cdc_pdm_lines_act &ext_sec_tlmm_lines_act>;
+	pinctrl-1 = <&cdc_pdm_lines_sus &ext_sec_tlmm_lines_sus>;
+
+	model = "alcatel-idol347";
+	audio-routing =
+		"AMIC1", "MIC BIAS External1",
+		"AMIC2", "MIC BIAS Internal2",
+		"AMIC3", "MIC BIAS External1";
+
+	dai-link-primary {
+		link-name = "Primary MI2S";
+		cpu {
+			sound-dai = <&lpass MI2S_PRIMARY>;
+		};
+		codec {
+			sound-dai = <&lpass_codec 0>, <&wcd_codec 0>;
+		};
+	};
+
+	dai-link-tertiary {
+		link-name = "Tertiary MI2S";
+		cpu {
+			sound-dai = <&lpass MI2S_TERTIARY>;
+		};
+		codec {
+			sound-dai = <&lpass_codec 1>, <&wcd_codec 1>;
+		};
+	};
+
+	dai-link-quaternary {
+		link-name = "Quaternary MI2S";
+		cpu {
+			sound-dai = <&lpass MI2S_QUATERNARY>;
+		};
+		codec {
+			sound-dai = <&speaker_codec_top>, <&speaker_codec_bottom>;
+		};
+	};
+};
+
 &usb {
 	status = "okay";
 	extcon = <&usb_id>, <&usb_id>;
@@ -222,6 +291,13 @@
 
 &usb_hs_phy {
 	extcon = <&usb_id>;
+};
+
+&wcd_codec {
+	qcom,micbias-lvl = <2800>;
+	qcom,mbhc-vthreshold-low = <75 100 120 180 500>;
+	qcom,mbhc-vthreshold-high = <75 100 120 180 500>;
+	qcom,hphl-jack-type-normally-open;
 };
 
 &smd_rpm_regulators {


### PR DESCRIPTION
Allows using the two tfa9897 chips (top and bottom) of idol3/idol347, where they manage both speaker and earpiece mode.
The added settings are optional : channel, reset-gpios, switch-gpios (to select speaker/earpiece mode) and vdd supply.
For example, on idol347 :
```
        speaker_codec_top: audio-codec@34 {
                compatible = "nxp,tfa9897";
                reg = <0x34>;
                channel = <0>; // 0: left, 1: right
                /* reset-gpios = <&msmgpio 51 GPIO_ACTIVE_HIGH>; */
                switch-gpios = <&msmgpio 50 GPIO_ACTIVE_HIGH>; /* 56 on older boards */
                vdd-supply = <&pm8916_l6>;
                #sound-dai-cells = <0>;
                sound-name-prefix = "Speaker Top";
        };

        speaker_codec_bottom: audio-codec@36 {
                compatible = "nxp,tfa9897";
                reg = <0x36>;
                channel = <1>;
                /* reset-gpios = <&msmgpio 51 GPIO_ACTIVE_HIGH>; */
                switch-gpios = <&msmgpio 111 GPIO_ACTIVE_HIGH>; /* 60 on older boards */
                vdd-supply = <&pm8916_l6>;
                #sound-dai-cells = <0>;
                sound-name-prefix = "Speaker Bottom";
        };

```