### PR TITLE
samsung-gt510wifi/matissevewifi: Fix touchscreen

### DIFF
--- a/arch/arm64/boot/dts/qcom/apq8016-samsung-gt510wifi.dts
+++ b/arch/arm64/boot/dts/qcom/apq8016-samsung-gt510wifi.dts
@@ -107,7 +107,6 @@
 
 		gpio = <&msmgpio 73 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
-		regulator-always-on; /* FIXME */
 
 		pinctrl-names = "default";
 		pinctrl-0 = <&tsp_en_default>;
@@ -121,7 +120,6 @@
 
 		gpio = <&msmgpio 73 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
-		regulator-always-on; /* FIXME */
 	};
 
 	// FIXME: Use extcon device provided by MUIC driver when available
@@ -140,7 +138,10 @@
 		interrupt-parent = <&msmgpio>;
 		interrupts = <13 IRQ_TYPE_EDGE_FALLING>;
 
-		reset-gpios = <&msmgpio 114 GPIO_ACTIVE_HIGH>;
+		vdd-supply = <&reg_tsp_1p8v>;
+		vdda-supply = <&reg_tsp_3p3v>;
+
+		reset-gpios = <&msmgpio 114 GPIO_ACTIVE_LOW>;
 
 		pinctrl-names = "default";
 		pinctrl-0 = <&tsp_int_rst_default>;

--- a/arch/arm64/boot/dts/qcom/apq8016-samsung-matissevewifi.dts
+++ b/arch/arm64/boot/dts/qcom/apq8016-samsung-matissevewifi.dts
@@ -98,7 +98,6 @@
 
 		gpio = <&msmgpio 73 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
-		regulator-always-on; /* FIXME */
 
 		pinctrl-names = "default";
 		pinctrl-0 = <&tsp_en_default>;
@@ -112,7 +111,6 @@
 
 		gpio = <&msmgpio 98 GPIO_ACTIVE_HIGH>;
 		enable-active-high;
-		regulator-always-on; /* FIXME */
 
 		pinctrl-names = "default";
 		pinctrl-0 = <&tsp_en1_default>;
@@ -164,7 +162,10 @@
 		interrupt-parent = <&msmgpio>;
 		interrupts = <13 IRQ_TYPE_EDGE_FALLING>;
 
-		reset-gpios = <&msmgpio 114 GPIO_ACTIVE_HIGH>;
+		vdd-supply = <&reg_tsp_1p8v>;
+		vdda-supply = <&reg_tsp_3p3v>;
+
+		reset-gpios = <&msmgpio 114 GPIO_ACTIVE_LOW>;
 
 		pinctrl-names = "default";
 		pinctrl-0 = <&tsp_int_rst_default>;


### PR DESCRIPTION
There was some upstream change recently where `reset-gpios` for atmel mxt should now be `GPIO_ACTIVE_LOW` instead of `GPIO_ACTIVE_HIGH`. This broke the touchscreen on gt510wifi (and probably matissevewifi). Also, the regulators can now be specified correctly.

Reported and tested by Luis on gt510wifi, so I'm just guessing matissevewifi works better with these changes as well.

Cc: @jja2000 @rvlander