### PR TITLE
WIP: arm64: dts: qcom: msm8916-ufi-1b: Add support for UFI-1B WiFi/LTE

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -960,6 +960,7 @@ dtb-$(CONFIG_ARCH_QCOM) += \
 	qcom-ipq8064-rb3011.dtb \
 	qcom-msm8226-samsung-s3ve3g.dtb \
 	qcom-msm8660-surf.dtb \
+	qcom-msm8916-ufi-1b.dtb \
 	qcom-msm8916-samsung-serranove.dtb \
 	qcom-msm8960-cdp.dtb \
 	qcom-msm8974-fairphone-fp2.dtb \

--- a/arch/arm/boot/dts/qcom-msm8916-ufi-1b.dts
+++ b/arch/arm/boot/dts/qcom-msm8916-ufi-1b.dts
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include "arm64/qcom/msm8916-ufi-1b.dts"
+#include "qcom-msm8916-smp.dtsi"

--- a/arch/arm64/boot/dts/qcom/msm8916-ufi-1b.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-ufi-1b.dts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include "msm8916-pm8916.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "ufi-1b";
+	compatible = "qcom,msm8916";
+	qcom,msm-id = <0xce 0x0 0xf8 0x0 0xf9 0x0 0xfa 0x0>;
+	qcom,board-id = <0x8 0x100>;
+
+	aliases {
+		serial0 = &blsp1_uart2;
+	};
+
+	chosen {
+		stdout-path = "serial0";
+	};
+
+	usb_id: usb-id {
+		compatible = "linux,extcon-usb-gpio";
+		id-gpios = <&msmgpio 110 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&usb_id_default>;
+	};
+};
+
+&blsp1_uart2 {
+	status = "okay";
+};
+
+&usb_hs_phy {
+	v1p8-supply = <&pm8916_l7>;
+	v3p3-supply = <&pm8916_l13>;
+	extcon = <&usb_id>;
+};
+
+&usb {
+	status = "okay";
+	extcon = <&usb_id>, <&usb_id>;
+};
+
+&sdhc_1 {
+	status = "okay";
+
+	pinctrl-names = "default", "sleep";
+	pinctrl-0 = <&sdc1_clk_on &sdc1_cmd_on &sdc1_data_on>;
+	pinctrl-1 = <&sdc1_clk_off &sdc1_cmd_off &sdc1_data_off>;
+};
+
+&smd_rpm_regulators {
+	vdd_l1_l2_l3-supply = <&pm8916_s3>;
+	vdd_l4_l5_l6-supply = <&pm8916_s4>;
+	vdd_l7-supply = <&pm8916_s4>;
+
+	s3 {
+		regulator-min-microvolt = <1200000>;
+		regulator-max-microvolt = <1300000>;
+	};
+
+	s4 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <2100000>;
+	};
+
+	l1 {
+		regulator-min-microvolt = <1225000>;
+		regulator-max-microvolt = <1225000>;
+	};
+
+	l2 {
+		regulator-min-microvolt = <1200000>;
+		regulator-max-microvolt = <1200000>;
+	};
+
+	l4 {
+		regulator-min-microvolt = <2050000>;
+		regulator-max-microvolt = <2050000>;
+	};
+
+	l5 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+	};
+
+	l6 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+	};
+
+	l7 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+	};
+
+	l8 {
+		regulator-min-microvolt = <2850000>;
+		regulator-max-microvolt = <2900000>;
+	};
+
+	l9 {
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+	};
+
+	l10 {
+		regulator-min-microvolt = <2700000>;
+		regulator-max-microvolt = <2800000>;
+	};
+
+	l11 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <2950000>;
+		regulator-allow-set-load;
+		regulator-system-load = <200000>;
+	};
+
+	l12 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <2950000>;
+	};
+
+	l13 {
+		regulator-min-microvolt = <3075000>;
+		regulator-max-microvolt = <3075000>;
+	};
+
+	l14 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3300000>;
+	};
+
+	l15 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3300000>;
+	};
+
+	l16 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3300000>;
+	};
+
+	l17 {
+		regulator-min-microvolt = <2850000>;
+		regulator-max-microvolt = <2850000>;
+	};
+
+	l18 {
+		regulator-min-microvolt = <2700000>;
+		regulator-max-microvolt = <2700000>;
+	};
+};
+
+&msmgpio {
+	usb_id_default: usb-id-default {
+		pins = "gpio110";
+		function = "gpio";
+
+		drive-strength = <8>;
+		bias-pull-up;
+	};
+};

--- a/arch/arm64/boot/dts/qcom/msm8916-ufi-1b.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-ufi-1b.dts
@@ -45,6 +45,21 @@
 		pinctrl-0 = <&usb_id_default>;
 	};
 
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&button>;
+
+		label = "GPIO Buttons";
+
+		volume-down {
+			label = "Volume Down";
+			gpios = <&msmgpio 37 GPIO_ACTIVE_HIGH>;
+			linux,code = <KEY_VOLUMEDOWN>;
+		};
+	};
+
 	leds {
 		compatible = "gpio-leds";
 
@@ -230,6 +245,14 @@
 
 		drive-strength = <8>;
 		bias-pull-up;
+	};
+
+	button: button {
+		pins = "gpio37";
+		function = "gpio";
+
+		bias-pull-down;
+		drive-strength = <2>;
 	};
 
 	gpio_leds: gpio-leds {

--- a/arch/arm64/boot/dts/qcom/msm8916-ufi-1b.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-ufi-1b.dts
@@ -44,6 +44,34 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&usb_id_default>;
 	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&gpio_leds>;
+
+		led-r {
+			gpios = <&msmgpio 22 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_RED>;
+			default-state = "off";
+			function = LED_FUNCTION_INDICATOR;
+		};
+
+		led-g {
+			gpios = <&msmgpio 21 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_GREEN>;
+			default-state = "on";
+			function = LED_FUNCTION_INDICATOR;
+		};
+
+		led-b {
+			gpios = <&msmgpio 20 GPIO_ACTIVE_HIGH>;
+			color = <LED_COLOR_ID_BLUE>;
+			default-state = "off";
+			function = LED_FUNCTION_INDICATOR;
+		};
+	};
 };
 
 &blsp1_uart2 {
@@ -202,6 +230,14 @@
 
 		drive-strength = <8>;
 		bias-pull-up;
+	};
+
+	gpio_leds: gpio-leds {
+		pins = "gpio20", "gpio21", "gpio22";
+		function = "gpio";
+
+		bias-disable;
+		drive-strength = <2>;
 	};
 
 	sim_ctrl: sim-ctrl {

--- a/arch/arm64/boot/dts/qcom/msm8916-ufi-1b.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-ufi-1b.dts
@@ -69,6 +69,22 @@
 	pinctrl-1 = <&sdc1_clk_off &sdc1_cmd_off &sdc1_data_off>;
 };
 
+&pronto {
+	status = "okay";
+
+	iris {
+		compatible = "qcom,wcn3620";
+	};
+};
+
+&bam_dmux {
+	status = "okay";
+};
+
+&bam_dmux_dma {
+	status = "okay";
+};
+
 &mpss {
 	status = "okay";
 

--- a/arch/arm64/boot/dts/qcom/msm8916-ufi-1b.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-ufi-1b.dts
@@ -20,6 +20,24 @@
 		stdout-path = "serial0";
 	};
 
+	reserved-memory {
+		mpss@86800000 {
+				reg = <0x00 0x86800000 0x00 0x5500000>;
+		};
+
+		wcnss@89300000 {
+				reg = <0x00 0x8BD00000 0x00 0x600000>;
+		};
+
+		venus@89900000 {
+				reg = <0x00 0x8C300000 0x00 0x600000>;
+		};
+
+		mba@8ea00000 {
+				reg = <0x00 0x8C900000 0x00 0x100000>;
+		};
+	};
+
 	usb_id: usb-id {
 		compatible = "linux,extcon-usb-gpio";
 		id-gpios = <&msmgpio 110 GPIO_ACTIVE_HIGH>;
@@ -49,6 +67,13 @@
 	pinctrl-names = "default", "sleep";
 	pinctrl-0 = <&sdc1_clk_on &sdc1_cmd_on &sdc1_data_on>;
 	pinctrl-1 = <&sdc1_clk_off &sdc1_cmd_off &sdc1_data_off>;
+};
+
+&mpss {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&sim_ctrl>;
 };
 
 &smd_rpm_regulators {
@@ -161,5 +186,14 @@
 
 		drive-strength = <8>;
 		bias-pull-up;
+	};
+
+	sim_ctrl: sim-ctrl {
+		pins = "gpio1", "gpio2";
+		function = "gpio";
+
+		bias-disable;
+		output-low;
+		drive-strength = <2>;
 	};
 };


### PR DESCRIPTION
This PR adds support for the UFI-1B WiFi/LTE dongle, based on the msm8916

I do not know if the device has a better name, since looks like its sold by multiple online stores under very generic terms
The default SSID is 4G-UFI-XX and there is a reference on the PCB itself which says `UFI001B_MB_V01`, so I went with `UFI-1B`.
Let me know if you think another name would be a better fit

Reference pic to show its _genericness_
![image](https://user-images.githubusercontent.com/88469/143604913-476ddd5e-d3be-482e-b6ca-a842f4f103dd.png)

