### PR TITLE
arm64: dts: qcom: msm8916-samsung-a5-zt: Add initial device tree

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -24,6 +24,7 @@ dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-motorola-surnia.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-mtp.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-oppo-a51f.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-a3u-eur.dtb
+dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-a5-zt.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-a5u-eur.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-gprime.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-gt510.dtb

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-a5-zt.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-a5-zt.dts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include "msm8916-samsung-a5u-eur.dts"
+
+/ {
+	model = "Samsung Galaxy A5 (SM-A500YZ)";
+	compatible = "samsung,a5-zt", "samsung,a5u-eur", "qcom,msm8916";
+	chassis-type = "handset";
+
+	/* NOTE: a5-zt doesn't actually have an NFC chip. */
+	i2c-nfc {
+		status = "disabled";
+	};
+};
+
+&accelerometer {
+	mount-matrix = "0", "1", "0",
+			"1", "0", "0",
+			"0", "0", "1";
+};
+
+&reg_touch_key {
+	gpio = <&msmgpio 60 GPIO_ACTIVE_HIGH>;
+};
+
+&tkey_en_default {
+	pins = "gpio60";
+};


### PR DESCRIPTION
Samsung Galaxy A5 (SM-A500YZ) is a smartphone using the MSM8916 SoC released
in 2015.

The A5 variants are very similar, with some differences in accelerometer and
touch key. The common parts are shared in msm8916-samsung-a5u-eur.dts to reduce
duplication.

The difference of accelerometer between A5U/A5ZT is the way the sensor is
mounted on the mainboard - set the mount-matrix in the
device-specific device tree part to handle that difference.

On A5ZT the touch key is supplied by a single fixed
regulator (enabled via GPIO 60) that supplies both MCU and LED.

A5ZT doesn't have an NFC chip.