### PR TITLE
arm: dts: qcom-msm8916-samsung-gprime: Add initial device tree

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -960,6 +960,7 @@ dtb-$(CONFIG_ARCH_QCOM) += \
 	qcom-ipq8064-rb3011.dtb \
 	qcom-msm8226-samsung-s3ve3g.dtb \
 	qcom-msm8660-surf.dtb \
+	qcom-msm8916-samsung-gprime.dtb \
 	qcom-msm8916-samsung-serranove.dtb \
 	qcom-msm8960-cdp.dtb \
 	qcom-msm8974-fairphone-fp2.dtb \

--- a/arch/arm/boot/dts/qcom-msm8916-samsung-gprime.dts
+++ b/arch/arm/boot/dts/qcom-msm8916-samsung-gprime.dts
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include "arm64/qcom/msm8916-samsung-gprime.dts"
+#include "qcom-msm8916-smp.dtsi"

--- a/arch/arm/boot/dts/qcom-msm8916-samsung-gprime.dts
+++ b/arch/arm/boot/dts/qcom-msm8916-samsung-gprime.dts
@@ -2,6 +2,34 @@
 #include "arm64/qcom/msm8916-samsung-gprime.dts"
 #include "qcom-msm8916-smp.dtsi"
 
+/ {
+	i2c-nfc {
+		compatible = "i2c-gpio";
+		sda-gpios = <&msmgpio 0 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&msmgpio 1 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&nfc_i2c_default>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		nfc@2b {
+			compatible = "nxp,pn547", "nxp,nxp-nci-i2c";
+			reg = <0x2b>;
+
+			interrupt-parent = <&msmgpio>;
+			interrupts = <21 IRQ_TYPE_EDGE_RISING>;
+
+			enable-gpios = <&msmgpio 20 GPIO_ACTIVE_HIGH>;
+			firmware-gpios = <&msmgpio 49 GPIO_ACTIVE_HIGH>;
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&nfc_default>;
+		};
+	};
+};
+
 &blsp_i2c2 {
 	status = "okay";
 
@@ -29,6 +57,30 @@
 &msmgpio {
 	accel_int_default: accel-int-default {
 		pins = "gpio115";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	nfc_default: nfc-default {
+		pins = "gpio20", "gpio49";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+
+		irq {
+			pins = "gpio21";
+			function = "gpio";
+
+			drive-strength = <2>;
+			bias-pull-down;
+		};
+	};
+
+	nfc_i2c_default: nfc-i2c-default {
+		pins = "gpio0", "gpio1";
 		function = "gpio";
 
 		drive-strength = <2>;

--- a/arch/arm/boot/dts/qcom-msm8916-samsung-gprime.dts
+++ b/arch/arm/boot/dts/qcom-msm8916-samsung-gprime.dts
@@ -1,3 +1,37 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #include "arm64/qcom/msm8916-samsung-gprime.dts"
 #include "qcom-msm8916-smp.dtsi"
+
+&blsp_i2c2 {
+	status = "okay";
+
+	accelerometer@1d {
+		compatible = "st,lis2hh12";
+		reg = <0x1d>;
+
+		vdd-supply = <&pm8916_l17>;
+		vddio-supply = <&pm8916_l5>;
+
+		interrupt-parent = <&msmgpio>;
+		interrupts = <115 IRQ_TYPE_EDGE_RISING>;
+		interrupt-names = "INT1";
+
+		st,drdy-int-pin = <1>;
+		mount-matrix = "1", "0", "0",
+			      "0", "-1", "0",
+			       "0", "0", "1";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&accel_int_default>;
+	};
+};
+
+&msmgpio {
+	accel_int_default: accel-int-default {
+		pins = "gpio115";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+};

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime.dts
@@ -3,6 +3,8 @@
 /dts-v1/;
 
 #include "msm8916-pm8916.dtsi"
+#include "msm8916-modem.dtsi"
+
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/interrupt-controller/irq.h>
@@ -37,6 +39,16 @@
 		/* Additional memory used by Samsung firmware modifications */
 		tz-apps@85500000 {
 			reg = <0x0 0x85500000 0x0 0xb00000>;
+			no-map;
+		};
+
+		mpss_mem: mpss@86800000 {
+			reg = <0x0 0x86800000 0x0 0x5a00000>;
+			no-map;
+		};
+
+		gps_mem: gps@8c200000 {
+			reg = <0x0 0x8c200000 0x0 0x200000>;
 			no-map;
 		};
 	};
@@ -208,6 +220,14 @@
 	pinctrl-1 = <&sdc2_clk_off &sdc2_cmd_off &sdc2_data_off &sdc2_cd_off>;
 
 	cd-gpios = <&msmgpio 38 GPIO_ACTIVE_LOW>;
+};
+
+&sound {
+	status = "okay";
+	audio-routing =
+		"AMIC1", "MIC BIAS External1",
+		"AMIC2", "MIC BIAS Internal2",
+		"AMIC3", "MIC BIAS External1";
 };
 
 &usb {

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime.dts
@@ -239,6 +239,16 @@
 	extcon = <&muic>;
 };
 
+&wcd_codec {
+	jack-gpios = <&msmgpio 110 GPIO_ACTIVE_LOW>;
+	qcom,micbias-lvl = <2800>;
+	qcom,mbhc-vthreshold-low = <75 150 237 450 500>;
+	qcom,mbhc-vthreshold-high = <75 150 237 450 500>;
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&jack_default>;
+};
+
 &smd_rpm_regulators {
 	vdd_l1_l2_l3-supply = <&pm8916_s3>;
 	vdd_l4_l5_l6-supply = <&pm8916_s4>;
@@ -357,6 +367,14 @@
 
 		drive-strength = <2>;
 		bias-pull-up;
+	};
+
+	jack_default: jack-default {
+		pins = "gpio110";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
 	};
 
 	lcd_on_default: lcd-on-default {

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime.dts
@@ -62,6 +62,19 @@
 		};
 	};
 
+	reg_vdd_lcd: regulator-vdd-lcd {
+		compatible = "regulator-fixed";
+		regulator-name = "vdd_lcd";
+		regulator-min-microvolt = <3000000>;
+		regulator-max-microvolt = <3000000>;
+
+		gpio = <&msmgpio 102 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&lcd_on_default>;
+	};
+
 	vibrator {
 		compatible = "gpio-vibrator";
 		enable-gpios = <&msmgpio 72 GPIO_ACTIVE_HIGH>;
@@ -102,6 +115,35 @@
 };
 
 &blsp1_uart2 {
+	status = "okay";
+};
+
+&dsi0 {
+	pinctrl-names = "default", "sleep";
+	pinctrl-0 = <&mdss_default>;
+	pinctrl-1 = <&mdss_sleep>;
+
+	panel@0 {
+		compatible = "samsung,gprime-panel";
+		reg = <0>;
+		vreg-supply = <&pm8916_l6>;
+		vdd-supply = <&reg_vdd_lcd>;
+		reset-gpios = <&msmgpio 25 GPIO_ACTIVE_LOW>;
+
+		port {
+			panel_in: endpoint {
+				remote-endpoint = <&dsi0_out>;
+			};
+		};
+	};
+};
+
+&dsi0_out {
+	data-lanes = <0 1>;
+	remote-endpoint = <&panel_in>;
+};
+
+&mdss {
 	status = "okay";
 };
 
@@ -259,6 +301,31 @@
 
 		drive-strength = <2>;
 		bias-pull-up;
+	};
+
+	lcd_on_default: lcd-on-default {
+		pins = "gpio102";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	mdss {
+		mdss_default: mdss-default {
+			pins = "gpio25";
+			function = "gpio";
+
+			drive-strength = <8>;
+			bias-disable;
+		};
+		mdss_sleep: mdss-sleep {
+			pins = "gpio25";
+			function = "gpio";
+
+			drive-strength = <2>;
+			bias-pull-down;
+		};
 	};
 
 	motor_en_default: motor-en-default {

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime.dts
@@ -75,6 +75,19 @@
 		pinctrl-0 = <&lcd_on_default>;
 	};
 
+	reg_vdd_tsp_a: regulator-vdd-tsp-a {
+		compatible = "regulator-fixed";
+		regulator-name = "vdd_tsp_a";
+		regulator-min-microvolt = <3000000>;
+		regulator-max-microvolt = <3000000>;
+
+		gpio = <&msmgpio 73 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&tsp_en_default>;
+	};
+
 	vibrator {
 		compatible = "gpio-vibrator";
 		enable-gpios = <&msmgpio 72 GPIO_ACTIVE_HIGH>;
@@ -111,6 +124,29 @@
 
 		pinctrl-names = "default";
 		pinctrl-0 = <&fg_alert_default>;
+	};
+};
+
+&blsp_i2c5 {
+	status = "okay";
+
+	touchscreen@20 {
+		compatible = "zinitix,bt541";
+
+		reg = <0x20>;
+		interrupt-parent = <&msmgpio>;
+		interrupts = <13 IRQ_TYPE_EDGE_FALLING>;
+
+		touchscreen-size-x = <540>;
+		touchscreen-size-y = <960>;
+
+		vdd-supply = <&reg_vdd_tsp_a>;
+		vddo-supply = <&pm8916_l6>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&tsp_int_default>;
+
+		linux,keycodes = <KEY_APPSELECT KEY_BACK>;
 	};
 };
 
@@ -338,6 +374,22 @@
 
 	muic_int_default: muic-int-default {
 		pins = "gpio12";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	tsp_en_default: tsp_en_default {
+		pins = "gpio73";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	tsp_int_default: tsp_int_default {
+		pins = "gpio13";
 		function = "gpio";
 
 		drive-strength = <2>;

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime.dts
@@ -4,7 +4,21 @@
 
 #include "msm8916-pm8916.dtsi"
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
 #include <dt-bindings/interrupt-controller/irq.h>
+
+/*
+ * NOTE: The original firmware from Samsung can only boot ARM32 kernels on some
+ * variants.
+ * Unfortunately, the firmware is signed and cannot be replaced easily.
+ * There seems to be no way to boot ARM64 kernels on 32-bit devices at the
+ * moment, even though the hardware would support it.
+ *
+ * However, it is possible to use this device tree by compiling an ARM32 kernel
+ * instead. For clarity and build testing this device tree is maintained next
+ * to the other MSM8916 device trees. However, it is actually used through
+ *   arch/arm/boot/dts/qcom-msm8916-samsung-gprime.dts
+ */
 
 / {
 	model = "Samsung Galaxy Grand Prime";
@@ -17,6 +31,35 @@
 
 	chosen {
 		stdout-path = "serial0";
+	};
+
+	reserved-memory {
+		/* Additional memory used by Samsung firmware modifications */
+		tz-apps@85500000 {
+			reg = <0x0 0x85500000 0x0 0xb00000>;
+			no-map;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&gpio_keys_default>;
+
+		label = "GPIO Buttons";
+
+		volume-up {
+			label = "Volume Up";
+			gpios = <&msmgpio 107 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_VOLUMEUP>;
+		};
+
+		home {
+			label = "Home";
+			gpios = <&msmgpio 109 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_HOMEPAGE>;
+		};
 	};
 };
 
@@ -36,6 +79,15 @@
 };
 
 &blsp1_uart2 {
+	status = "okay";
+};
+
+&pm8916_resin {
+	status = "okay";
+	linux,code = <KEY_VOLUMEDOWN>;
+};
+
+&pronto {
 	status = "okay";
 };
 
@@ -170,6 +222,14 @@
 };
 
 &msmgpio {
+	gpio_keys_default: gpio-keys-default {
+		pins = "gpio107", "gpio109";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-pull-up;
+	};
+
 	muic_int_default: muic-int-default {
 		pins = "gpio12";
 		function = "gpio";

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime.dts
@@ -86,6 +86,21 @@
 	};
 };
 
+&blsp_i2c4 {
+	status = "okay";
+
+	battery@35 {
+		compatible = "richtek,rt5033-battery";
+		reg = <0x35>;
+
+		interrupt-parent = <&msmgpio>;
+		interrupts = <121 IRQ_TYPE_EDGE_FALLING>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&fg_alert_default>;
+	};
+};
+
 &blsp1_uart2 {
 	status = "okay";
 };
@@ -230,6 +245,14 @@
 };
 
 &msmgpio {
+	fg_alert_default: fg-alert-default {
+		pins = "gpio121";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
 	gpio_keys_default: gpio-keys-default {
 		pins = "gpio107", "gpio109";
 		function = "gpio";

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime.dts
@@ -61,6 +61,14 @@
 			linux,code = <KEY_HOMEPAGE>;
 		};
 	};
+
+	vibrator {
+		compatible = "gpio-vibrator";
+		enable-gpios = <&msmgpio 72 GPIO_ACTIVE_HIGH>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&motor_en_default>;
+	};
 };
 
 &blsp_i2c1 {
@@ -228,6 +236,14 @@
 
 		drive-strength = <2>;
 		bias-pull-up;
+	};
+
+	motor_en_default: motor-en-default {
+		pins = "gpio72";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
 	};
 
 	muic_int_default: muic-int-default {

--- a/drivers/gpu/drm/panel/msm8916-generated/Makefile
+++ b/drivers/gpu/drm/panel/msm8916-generated/Makefile
@@ -12,6 +12,7 @@ obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-motorola-osprey-inx.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-motorola-surnia-boe.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-oppo-15009-nt35592-jdi.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-ea8061v-ams497ee01.o
+obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-hx8389c.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-nt51017-b4p096wx5vp09.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-s6d7aa0-lsl080al03.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-s6d7aa0-ltl101at01.o

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-hx8389c.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-hx8389c.c
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2022 FIXME
+// Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
+//   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
+
+#include <linux/backlight.h>
+#include <linux/delay.h>
+#include <linux/gpio/consumer.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/regulator/consumer.h>
+
+#include <video/mipi_display.h>
+
+#include <drm/drm_mipi_dsi.h>
+#include <drm/drm_modes.h>
+#include <drm/drm_panel.h>
+
+struct samsung_hx8389c {
+	struct drm_panel panel;
+	struct mipi_dsi_device *dsi;
+	struct regulator_bulk_data supplies[2];
+	struct gpio_desc *reset_gpio;
+	bool prepared;
+};
+
+static inline struct samsung_hx8389c *to_samsung_hx8389c(struct drm_panel *panel)
+{
+	return container_of(panel, struct samsung_hx8389c, panel);
+}
+
+#define dsi_dcs_write_seq(dsi, seq...) do {				\
+		static const u8 d[] = { seq };				\
+		int ret;						\
+		ret = mipi_dsi_dcs_write_buffer(dsi, d, ARRAY_SIZE(d));	\
+		if (ret < 0)						\
+			return ret;					\
+	} while (0)
+
+static void samsung_hx8389c_reset(struct samsung_hx8389c *ctx)
+{
+	gpiod_set_value_cansleep(ctx->reset_gpio, 0);
+	usleep_range(10000, 11000);
+	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+	usleep_range(2000, 3000);
+	gpiod_set_value_cansleep(ctx->reset_gpio, 0);
+	msleep(80);
+}
+
+static int samsung_hx8389c_on(struct samsung_hx8389c *ctx)
+{
+	struct mipi_dsi_device *dsi = ctx->dsi;
+	struct device *dev = &dsi->dev;
+	int ret;
+
+	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+
+	dsi_dcs_write_seq(dsi, 0xb9, 0xff, 0x83, 0x89);
+	usleep_range(10000, 11000);
+	dsi_dcs_write_seq(dsi, 0xb1,
+			  0x7f, 0x10, 0x10, 0xd2, 0x32, 0x80, 0x10, 0xf0, 0x56,
+			  0x80, 0x20, 0x20, 0xf8, 0xaa, 0xaa, 0xa1, 0x00, 0x80,
+			  0x30, 0x00);
+	dsi_dcs_write_seq(dsi, 0xb2,
+			  0x82, 0x50, 0x05, 0x07, 0xf0, 0x38, 0x11, 0x64, 0x5d,
+			  0x09);
+	dsi_dcs_write_seq(dsi, 0xb4,
+			  0x66, 0x66, 0x66, 0x70, 0x00, 0x00, 0x18, 0x76, 0x28,
+			  0x76, 0xa8);
+	dsi_dcs_write_seq(dsi, 0xd2, 0x33);
+	dsi_dcs_write_seq(dsi, 0xc0, 0x30, 0x17, 0x00, 0x03);
+	dsi_dcs_write_seq(dsi, 0xc7, 0x00, 0x80, 0x00, 0xc0);
+	dsi_dcs_write_seq(dsi, 0xbf, 0x05, 0x50, 0x00, 0x3e);
+	usleep_range(10000, 11000);
+	dsi_dcs_write_seq(dsi, 0xb9, 0xff, 0x83, 0x89);
+	dsi_dcs_write_seq(dsi, 0xcc, 0x0e);
+	dsi_dcs_write_seq(dsi, 0xd3,
+			  0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x32, 0x10,
+			  0x00, 0x00, 0x00, 0x03, 0xc6, 0x03, 0xc6, 0x00, 0x00,
+			  0x00, 0x00, 0x35, 0x33, 0x04, 0x04, 0x37, 0x00, 0x00,
+			  0x00, 0x05, 0x08, 0x00, 0x00, 0x0a, 0x00, 0x01);
+	dsi_dcs_write_seq(dsi, 0xd5,
+			  0x18, 0x18, 0x18, 0x18, 0x19, 0x19, 0x18, 0x18, 0x20,
+			  0x21, 0x24, 0x25, 0x18, 0x18, 0x18, 0x18, 0x00, 0x01,
+			  0x04, 0x05, 0x02, 0x03, 0x06, 0x07, 0x18, 0x18, 0x18,
+			  0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18,
+			  0x18, 0x18);
+	dsi_dcs_write_seq(dsi, 0xd6,
+			  0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x19, 0x19, 0x25,
+			  0x24, 0x21, 0x20, 0x18, 0x18, 0x18, 0x18, 0x07, 0x06,
+			  0x03, 0x02, 0x05, 0x04, 0x01, 0x00, 0x18, 0x18, 0x18,
+			  0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18,
+			  0x18, 0x18);
+	dsi_dcs_write_seq(dsi, 0xb7, 0x20, 0x80, 0x00);
+	dsi_dcs_write_seq(dsi, 0xe0,
+			  0x00, 0x02, 0x06, 0x38, 0x3c, 0x3f, 0x1b, 0x46, 0x06,
+			  0x09, 0x0c, 0x17, 0x10, 0x13, 0x16, 0x13, 0x14, 0x08,
+			  0x13, 0x15, 0x19, 0x00, 0x02, 0x06, 0x37, 0x3c, 0x3f,
+			  0x1a, 0x45, 0x05, 0x09, 0x0b, 0x16, 0x0f, 0x13, 0x15,
+			  0x13, 0x14, 0x07, 0x12, 0x14, 0x18);
+	dsi_dcs_write_seq(dsi, 0xbd, 0x00);
+	dsi_dcs_write_seq(dsi, 0xc1,
+			  0x00, 0x00, 0x08, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38,
+			  0x40, 0x48, 0x50, 0x58, 0x60, 0x68, 0x70, 0x78, 0x80,
+			  0x88, 0x90, 0x98, 0xa0, 0xa8, 0xb0, 0xb8, 0xc0, 0xc8,
+			  0xd0, 0xd8, 0xe0, 0xe8, 0xf0, 0xf8, 0xff, 0x00, 0x00,
+			  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_dcs_write_seq(dsi, 0xbd, 0x01);
+	dsi_dcs_write_seq(dsi, 0xc1,
+			  0x00, 0x08, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38, 0x40,
+			  0x48, 0x50, 0x58, 0x60, 0x68, 0x70, 0x78, 0x80, 0x88,
+			  0x90, 0x98, 0xa0, 0xa8, 0xb0, 0xb8, 0xc0, 0xc8, 0xd0,
+			  0xd8, 0xe0, 0xe8, 0xf0, 0xf8, 0xff, 0x00, 0x00, 0x00,
+			  0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_dcs_write_seq(dsi, 0xbd, 0x02);
+	dsi_dcs_write_seq(dsi, 0xc1,
+			  0x00, 0x08, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38, 0x40,
+			  0x48, 0x50, 0x58, 0x60, 0x68, 0x70, 0x78, 0x80, 0x88,
+			  0x90, 0x98, 0xa0, 0xa8, 0xb0, 0xb8, 0xc0, 0xc8, 0xd0,
+			  0xd8, 0xe0, 0xe8, 0xf0, 0xf8, 0xff, 0x00, 0x00, 0x00,
+			  0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_dcs_write_seq(dsi, 0xc9,
+			  0x1f, 0x00, 0x0f, 0x1e, 0x81, 0x1e, 0x00, 0x00, 0x01,
+			  0x19, 0x00, 0x00, 0x20);
+	usleep_range(5000, 6000);
+	dsi_dcs_write_seq(dsi, MIPI_DCS_WRITE_POWER_SAVE, 0x00);
+	usleep_range(5000, 6000);
+	dsi_dcs_write_seq(dsi, MIPI_DCS_WRITE_CONTROL_DISPLAY, 0x24);
+	usleep_range(5000, 6000);
+
+	ret = mipi_dsi_dcs_exit_sleep_mode(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to exit sleep mode: %d\n", ret);
+		return ret;
+	}
+	msleep(125);
+
+	ret = mipi_dsi_dcs_set_display_on(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to set display on: %d\n", ret);
+		return ret;
+	}
+	usleep_range(5000, 6000);
+
+	return 0;
+}
+
+static int samsung_hx8389c_off(struct samsung_hx8389c *ctx)
+{
+	struct mipi_dsi_device *dsi = ctx->dsi;
+
+	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
+
+	dsi_dcs_write_seq(dsi, 0x28, 0x00);
+	msleep(60);
+	dsi_dcs_write_seq(dsi, 0x10, 0x00);
+	msleep(60);
+
+	return 0;
+}
+
+static int samsung_hx8389c_prepare(struct drm_panel *panel)
+{
+	struct samsung_hx8389c *ctx = to_samsung_hx8389c(panel);
+	struct device *dev = &ctx->dsi->dev;
+	int ret;
+
+	if (ctx->prepared)
+		return 0;
+
+	ret = regulator_bulk_enable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+	if (ret < 0) {
+		dev_err(dev, "Failed to enable regulators: %d\n", ret);
+		return ret;
+	}
+
+	samsung_hx8389c_reset(ctx);
+
+	ret = samsung_hx8389c_on(ctx);
+	if (ret < 0) {
+		dev_err(dev, "Failed to initialize panel: %d\n", ret);
+		gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+		regulator_bulk_disable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+		return ret;
+	}
+
+	ctx->prepared = true;
+	return 0;
+}
+
+static int samsung_hx8389c_unprepare(struct drm_panel *panel)
+{
+	struct samsung_hx8389c *ctx = to_samsung_hx8389c(panel);
+	struct device *dev = &ctx->dsi->dev;
+	int ret;
+
+	if (!ctx->prepared)
+		return 0;
+
+	ret = samsung_hx8389c_off(ctx);
+	if (ret < 0)
+		dev_err(dev, "Failed to un-initialize panel: %d\n", ret);
+
+	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+	regulator_bulk_disable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+
+	ctx->prepared = false;
+	return 0;
+}
+
+static const struct drm_display_mode samsung_hx8389c_mode = {
+	.clock = (540 + 10 + 14 + 10) * (960 + 9 + 2 + 5) * 60 / 1000,
+	.hdisplay = 540,
+	.hsync_start = 540 + 10,
+	.hsync_end = 540 + 10 + 14,
+	.htotal = 540 + 10 + 14 + 10,
+	.vdisplay = 960,
+	.vsync_start = 960 + 9,
+	.vsync_end = 960 + 9 + 2,
+	.vtotal = 960 + 9 + 2 + 5,
+	.width_mm = 62,
+	.height_mm = 110,
+};
+
+static int samsung_hx8389c_get_modes(struct drm_panel *panel,
+			     struct drm_connector *connector)
+{
+	struct drm_display_mode *mode;
+
+	mode = drm_mode_duplicate(connector->dev, &samsung_hx8389c_mode);
+	if (!mode)
+		return -ENOMEM;
+
+	drm_mode_set_name(mode);
+
+	mode->type = DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED;
+	connector->display_info.width_mm = mode->width_mm;
+	connector->display_info.height_mm = mode->height_mm;
+	drm_mode_probed_add(connector, mode);
+
+	return 1;
+}
+
+static const struct drm_panel_funcs samsung_hx8389c_panel_funcs = {
+	.prepare = samsung_hx8389c_prepare,
+	.unprepare = samsung_hx8389c_unprepare,
+	.get_modes = samsung_hx8389c_get_modes,
+};
+
+static int samsung_hx8389c_bl_update_status(struct backlight_device *bl)
+{
+	struct mipi_dsi_device *dsi = bl_get_data(bl);
+	u16 brightness = backlight_get_brightness(bl);
+	int ret;
+
+	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
+
+	ret = mipi_dsi_dcs_set_display_brightness(dsi, brightness);
+	if (ret < 0)
+		return ret;
+
+	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+
+	return 0;
+}
+
+// TODO: Check if /sys/class/backlight/.../actual_brightness actually returns
+// correct values. If not, remove this function.
+static int samsung_hx8389c_bl_get_brightness(struct backlight_device *bl)
+{
+	struct mipi_dsi_device *dsi = bl_get_data(bl);
+	u16 brightness;
+	int ret;
+
+	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
+
+	ret = mipi_dsi_dcs_get_display_brightness(dsi, &brightness);
+	if (ret < 0)
+		return ret;
+
+	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+
+	return brightness & 0xff;
+}
+
+static const struct backlight_ops samsung_hx8389c_bl_ops = {
+	.update_status = samsung_hx8389c_bl_update_status,
+	.get_brightness = samsung_hx8389c_bl_get_brightness,
+};
+
+static struct backlight_device *
+samsung_hx8389c_create_backlight(struct mipi_dsi_device *dsi)
+{
+	struct device *dev = &dsi->dev;
+	const struct backlight_properties props = {
+		.type = BACKLIGHT_RAW,
+		.brightness = 255,
+		.max_brightness = 255,
+	};
+
+	return devm_backlight_device_register(dev, dev_name(dev), dev, dsi,
+					      &samsung_hx8389c_bl_ops, &props);
+}
+
+static int samsung_hx8389c_probe(struct mipi_dsi_device *dsi)
+{
+	struct device *dev = &dsi->dev;
+	struct samsung_hx8389c *ctx;
+	int ret;
+
+	ctx = devm_kzalloc(dev, sizeof(*ctx), GFP_KERNEL);
+	if (!ctx)
+		return -ENOMEM;
+
+	ctx->supplies[0].supply = "vreg";
+	ctx->supplies[1].supply = "vdd";
+	ret = devm_regulator_bulk_get(dev, ARRAY_SIZE(ctx->supplies),
+				      ctx->supplies);
+	if (ret < 0)
+		return dev_err_probe(dev, ret, "Failed to get regulators\n");
+
+	ctx->reset_gpio = devm_gpiod_get(dev, "reset", GPIOD_OUT_HIGH);
+	if (IS_ERR(ctx->reset_gpio))
+		return dev_err_probe(dev, PTR_ERR(ctx->reset_gpio),
+				     "Failed to get reset-gpios\n");
+
+	ctx->dsi = dsi;
+	mipi_dsi_set_drvdata(dsi, ctx);
+
+	dsi->lanes = 2;
+	dsi->format = MIPI_DSI_FMT_RGB888;
+	dsi->mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_SYNC_PULSE |
+			  MIPI_DSI_MODE_NO_EOT_PACKET |
+			  MIPI_DSI_CLOCK_NON_CONTINUOUS;
+
+	drm_panel_init(&ctx->panel, dev, &samsung_hx8389c_panel_funcs,
+		       DRM_MODE_CONNECTOR_DSI);
+
+	ctx->panel.backlight = samsung_hx8389c_create_backlight(dsi);
+	if (IS_ERR(ctx->panel.backlight))
+		return dev_err_probe(dev, PTR_ERR(ctx->panel.backlight),
+				     "Failed to create backlight\n");
+
+	drm_panel_add(&ctx->panel);
+
+	ret = mipi_dsi_attach(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to attach to DSI host: %d\n", ret);
+		drm_panel_remove(&ctx->panel);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int samsung_hx8389c_remove(struct mipi_dsi_device *dsi)
+{
+	struct samsung_hx8389c *ctx = mipi_dsi_get_drvdata(dsi);
+	int ret;
+
+	ret = mipi_dsi_detach(dsi);
+	if (ret < 0)
+		dev_err(&dsi->dev, "Failed to detach from DSI host: %d\n", ret);
+
+	drm_panel_remove(&ctx->panel);
+
+	return 0;
+}
+
+static const struct of_device_id samsung_hx8389c_of_match[] = {
+	{ .compatible = "samsung,hx8389c" }, // FIXME
+	{ /* sentinel */ }
+};
+MODULE_DEVICE_TABLE(of, samsung_hx8389c_of_match);
+
+static struct mipi_dsi_driver samsung_hx8389c_driver = {
+	.probe = samsung_hx8389c_probe,
+	.remove = samsung_hx8389c_remove,
+	.driver = {
+		.name = "panel-samsung-hx8389c",
+		.of_match_table = samsung_hx8389c_of_match,
+	},
+};
+module_mipi_dsi_driver(samsung_hx8389c_driver);
+
+MODULE_AUTHOR("linux-mdss-dsi-panel-driver-generator <fix@me>"); // FIXME
+MODULE_DESCRIPTION("DRM driver for HX8389C qhd video mode dsi panel");
+MODULE_LICENSE("GPL v2");

--- a/drivers/thermal/qcom/tsens.c
+++ b/drivers/thermal/qcom/tsens.c
@@ -825,6 +825,7 @@ int __init init_common(struct tsens_priv *priv)
 	if (tsens_version(priv) == VER_0)
 		regmap_field_write(priv->rf[TSENS_EN], 1);
 
+	/*HACK For gprime
 	ret = regmap_field_read(priv->rf[TSENS_EN], &enabled);
 	if (ret)
 		goto err_put_device;
@@ -833,6 +834,7 @@ int __init init_common(struct tsens_priv *priv)
 		ret = -ENODEV;
 		goto err_put_device;
 	}
+	*/
 
 	priv->rf[SENSOR_EN] = devm_regmap_field_alloc(dev, priv->srot_map,
 						      priv->fields[SENSOR_EN]);


### PR DESCRIPTION
It looks not so great to drop tsens. Hope there is a solution to it.
[gprimearmv7.log](https://github.com/msm8916-mainline/linux/files/7925966/gprimearmv7.log)