### PR TITLE
arm64: dts: qcom: msm8916-samsung-fortunaltezt: Add initial device tree

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -960,6 +960,7 @@ dtb-$(CONFIG_ARCH_QCOM) += \
 	qcom-ipq8064-rb3011.dtb \
 	qcom-msm8226-samsung-s3ve3g.dtb \
 	qcom-msm8660-surf.dtb \
+	qcom-msm8916-samsung-fortunaltezt.dtb \
 	qcom-msm8916-samsung-serranove.dtb \
 	qcom-msm8960-cdp.dtb \
 	qcom-msm8974-fairphone-fp2.dtb \

--- a/arch/arm/boot/dts/qcom-msm8916-samsung-fortunaltezt.dts
+++ b/arch/arm/boot/dts/qcom-msm8916-samsung-fortunaltezt.dts
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include "arm64/qcom/msm8916-samsung-fortunaltezt.dts"
+#include "qcom-msm8916-smp.dtsi"

--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -28,7 +28,6 @@ dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-oppo-a51f.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-a3u-eur.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-a5-zt.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-a5u-eur.dtb
-dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-gprime.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-gt510.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-gt58.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-j5.dtb

--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -28,6 +28,7 @@ dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-oppo-a51f.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-a3u-eur.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-a5-zt.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-a5u-eur.dtb
+dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-fortunaltezt.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-gt510.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-gt58.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-j5.dtb

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
@@ -38,6 +38,32 @@
 			no-map;
 		};
 	};
+
+	i2c-nfc {
+		compatible = "i2c-gpio";
+		sda-gpios = <&msmgpio 0 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&msmgpio 1 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&nfc_i2c_default>;
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		nfc@2b {
+			compatible = "nxp,pn547", "nxp,nxp-nci-i2c";
+			reg = <0x2b>;
+
+			interrupt-parent = <&msmgpio>;
+			interrupts = <21 IRQ_TYPE_EDGE_RISING>;
+
+			enable-gpios = <&msmgpio 20 GPIO_ACTIVE_HIGH>;
+			firmware-gpios = <&msmgpio 49 GPIO_ACTIVE_HIGH>;
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&nfc_default>;
+		};
+	};
 };
 
 &blsp_i2c2 {
@@ -71,6 +97,30 @@
 &msmgpio {
 	accel_int_default: accel-int-default {
 		pins = "gpio115";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	nfc_default: nfc-default {
+		pins = "gpio20", "gpio49";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+
+		irq {
+			pins = "gpio21";
+			function = "gpio";
+
+			drive-strength = <2>;
+			bias-pull-down;
+		};
+	};
+
+	nfc_i2c_default: nfc-i2c-default {
+		pins = "gpio0", "gpio1";
 		function = "gpio";
 
 		drive-strength = <2>;

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
@@ -39,3 +39,37 @@
 		};
 	};
 };
+
+&blsp_i2c2 {
+	status = "okay";
+
+	accelerometer@1d {
+		compatible = "st,lis2hh12";
+		reg = <0x1d>;
+
+		vdd-supply = <&pm8916_l17>;
+		vddio-supply = <&pm8916_l5>;
+
+		interrupt-parent = <&msmgpio>;
+		interrupts = <115 IRQ_TYPE_EDGE_RISING>;
+		interrupt-names = "INT1";
+
+		st,drdy-int-pin = <1>;
+		mount-matrix = "1", "0", "0",
+			      "0", "-1", "0",
+			       "0", "0", "1";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&accel_int_default>;
+	};
+};
+
+&msmgpio {
+	accel_int_default: accel-int-default {
+		pins = "gpio115";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+};

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include "msm8916-samsung-gprime-common.dtsi"
+
+/*
+ * NOTE: The original firmware from Samsung can only boot ARM32 kernels.
+ * Unfortunately, the firmware is signed and cannot be replaced easily.
+ * There seems to be no way to boot ARM64 kernels on this device at the moment,
+ * even though the hardware would support it.
+ *
+ * However, it is possible to use this device tree by compiling an ARM32 kernel
+ * instead. For clarity and build testing this device tree is maintained next
+ * to the other MSM8916 device trees. However, it is actually used through
+ * arch/arm/boot/dts/qcom-msm8916-samsung-fortunaltezt.dts
+ */
+
+/ {
+	model = "Samsung Galaxy Grand Prime (SM-G530Y)";
+	compatible = "samsung,fortunaltezt", "samsung,gprime", "qcom,msm8916";
+	chassis-type = "handset";
+
+	reserved-memory {
+		/* Additional memory used by Samsung firmware modifications */
+		tz-apps@85a00000 {
+			reg = <0x0 0x85a00000 0x0 0x600000>;
+			no-map;
+		};
+
+		mpss_mem: mpss@86800000 {
+			reg = <0x0 0x86800000 0x0 0x5a00000>;
+			no-map;
+		};
+
+		gps_mem: gps@8c200000 {
+			reg = <0x0 0x8c200000 0x0 0x200000>;
+			no-map;
+		};
+	};
+};

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
@@ -64,6 +64,10 @@
 	};
 };
 
+&panel {
+    compatible = "samsung,hx8389c";
+};
+
 &msmgpio {
 	accel_int_default: accel-int-default {
 		pins = "gpio115";

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
@@ -91,7 +91,7 @@
 };
 
 &panel {
-    compatible = "samsung,hx8389c";
+    compatible = "samsung,hx8389c-gh9607501a";
 };
 
 &msmgpio {

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
@@ -1,22 +1,38 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
-/dts-v1/;
-
 #include "msm8916-pm8916.dtsi"
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
 #include <dt-bindings/interrupt-controller/irq.h>
 
 / {
-	model = "Samsung Galaxy Grand Prime";
-	compatible = "samsung,gprime", "qcom,msm8916";
-	chassis-type = "handset";
-
 	aliases {
 		serial0 = &blsp1_uart2;
 	};
 
 	chosen {
 		stdout-path = "serial0";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&gpio_keys_default>;
+
+		label = "GPIO Buttons";
+
+		volume-up {
+			label = "Volume Up";
+			gpios = <&msmgpio 107 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_VOLUMEUP>;
+		};
+
+		home {
+			label = "Home";
+			gpios = <&msmgpio 109 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_HOMEPAGE>;
+		};
 	};
 };
 
@@ -36,6 +52,15 @@
 };
 
 &blsp1_uart2 {
+	status = "okay";
+};
+
+&pm8916_resin {
+	status = "okay";
+	linux,code = <KEY_VOLUMEDOWN>;
+};
+
+&pronto {
 	status = "okay";
 };
 
@@ -170,6 +195,14 @@
 };
 
 &msmgpio {
+	gpio_keys_default: gpio-keys-default {
+		pins = "gpio107", "gpio109";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-pull-up;
+	};
+
 	muic_int_default: muic-int-default {
 		pins = "gpio12";
 		function = "gpio";

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
@@ -48,6 +48,19 @@
 		pinctrl-0 = <&lcd_on_default>;
 	};
 
+	reg_vdd_tsp_a: regulator-vdd-tsp-a {
+		compatible = "regulator-fixed";
+		regulator-name = "vdd_tsp_a";
+		regulator-min-microvolt = <3000000>;
+		regulator-max-microvolt = <3000000>;
+
+		gpio = <&msmgpio 73 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&tsp_en_default>;
+	};
+
 	vibrator {
 		compatible = "gpio-vibrator";
 		enable-gpios = <&msmgpio 72 GPIO_ACTIVE_HIGH>;
@@ -84,6 +97,29 @@
 
 		pinctrl-names = "default";
 		pinctrl-0 = <&fg_alert_default>;
+	};
+};
+
+&blsp_i2c5 {
+	status = "okay";
+
+	touchscreen@20 {
+		compatible = "zinitix,bt541";
+
+		reg = <0x20>;
+		interrupt-parent = <&msmgpio>;
+		interrupts = <13 IRQ_TYPE_EDGE_FALLING>;
+
+		touchscreen-size-x = <540>;
+		touchscreen-size-y = <960>;
+
+		vdd-supply = <&reg_vdd_tsp_a>;
+		vddo-supply = <&pm8916_l6>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&tsp_int_default>;
+
+		linux,keycodes = <KEY_APPSELECT KEY_BACK>;
 	};
 };
 
@@ -311,6 +347,22 @@
 
 	muic_int_default: muic-int-default {
 		pins = "gpio12";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	tsp_en_default: tsp_en_default {
+		pins = "gpio73";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	tsp_int_default: tsp_int_default {
+		pins = "gpio13";
 		function = "gpio";
 
 		drive-strength = <2>;

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
@@ -34,6 +34,14 @@
 			linux,code = <KEY_HOMEPAGE>;
 		};
 	};
+
+	vibrator {
+		compatible = "gpio-vibrator";
+		enable-gpios = <&msmgpio 72 GPIO_ACTIVE_HIGH>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&motor_en_default>;
+	};
 };
 
 &blsp_i2c1 {
@@ -201,6 +209,14 @@
 
 		drive-strength = <2>;
 		bias-pull-up;
+	};
+
+	motor_en_default: motor-en-default {
+		pins = "gpio72";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
 	};
 
 	muic_int_default: muic-int-default {

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
@@ -35,6 +35,19 @@
 		};
 	};
 
+	reg_vdd_lcd: regulator-vdd-lcd {
+		compatible = "regulator-fixed";
+		regulator-name = "vdd_lcd";
+		regulator-min-microvolt = <3000000>;
+		regulator-max-microvolt = <3000000>;
+
+		gpio = <&msmgpio 102 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&lcd_on_default>;
+	};
+
 	vibrator {
 		compatible = "gpio-vibrator";
 		enable-gpios = <&msmgpio 72 GPIO_ACTIVE_HIGH>;
@@ -75,6 +88,35 @@
 };
 
 &blsp1_uart2 {
+	status = "okay";
+};
+
+&dsi0 {
+	pinctrl-names = "default", "sleep";
+	pinctrl-0 = <&mdss_default>;
+	pinctrl-1 = <&mdss_sleep>;
+
+	panel: panel@0 {
+		compatible = "samsung,gprime-panel";
+		reg = <0>;
+		vreg-supply = <&pm8916_l6>;
+		vdd-supply = <&reg_vdd_lcd>;
+		reset-gpios = <&msmgpio 25 GPIO_ACTIVE_LOW>;
+
+		port {
+			panel_in: endpoint {
+				remote-endpoint = <&dsi0_out>;
+			};
+		};
+	};
+};
+
+&dsi0_out {
+	data-lanes = <0 1>;
+	remote-endpoint = <&panel_in>;
+};
+
+&mdss {
 	status = "okay";
 };
 
@@ -232,6 +274,31 @@
 
 		drive-strength = <2>;
 		bias-pull-up;
+	};
+
+	lcd_on_default: lcd-on-default {
+		pins = "gpio102";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	mdss {
+		mdss_default: mdss-default {
+			pins = "gpio25";
+			function = "gpio";
+
+			drive-strength = <8>;
+			bias-disable;
+		};
+		mdss_sleep: mdss-sleep {
+			pins = "gpio25";
+			function = "gpio";
+
+			drive-strength = <2>;
+			bias-pull-down;
+		};
 	};
 
 	motor_en_default: motor-en-default {

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
@@ -59,6 +59,21 @@
 	};
 };
 
+&blsp_i2c4 {
+	status = "okay";
+
+	battery@35 {
+		compatible = "richtek,rt5033-battery";
+		reg = <0x35>;
+
+		interrupt-parent = <&msmgpio>;
+		interrupts = <121 IRQ_TYPE_EDGE_FALLING>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&fg_alert_default>;
+	};
+};
+
 &blsp1_uart2 {
 	status = "okay";
 };
@@ -203,6 +218,14 @@
 };
 
 &msmgpio {
+	fg_alert_default: fg-alert-default {
+		pins = "gpio121";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
 	gpio_keys_default: gpio-keys-default {
 		pins = "gpio107", "gpio109";
 		function = "gpio";

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
@@ -202,6 +202,16 @@
 	extcon = <&muic>;
 };
 
+&wcd_codec {
+	jack-gpios = <&msmgpio 110 GPIO_ACTIVE_LOW>;
+	qcom,micbias-lvl = <2800>;
+	qcom,mbhc-vthreshold-low = <75 150 237 450 500>;
+	qcom,mbhc-vthreshold-high = <75 150 237 450 500>;
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&jack_default>;
+};
+
 &smd_rpm_regulators {
 	vdd_l1_l2_l3-supply = <&pm8916_s3>;
 	vdd_l4_l5_l6-supply = <&pm8916_s4>;
@@ -320,6 +330,14 @@
 
 		drive-strength = <2>;
 		bias-pull-up;
+	};
+
+	jack_default: jack-default {
+		pins = "gpio110";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
 	};
 
 	lcd_on_default: lcd-on-default {

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include "msm8916-pm8916.dtsi"
+#include "msm8916-modem.dtsi"
+
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
 #include <dt-bindings/interrupt-controller/irq.h>
@@ -181,6 +183,14 @@
 	pinctrl-1 = <&sdc2_clk_off &sdc2_cmd_off &sdc2_data_off &sdc2_cd_off>;
 
 	cd-gpios = <&msmgpio 38 GPIO_ACTIVE_LOW>;
+};
+
+&sound {
+	status = "okay";
+	audio-routing =
+		"AMIC1", "MIC BIAS External1",
+		"AMIC2", "MIC BIAS Internal2",
+		"AMIC3", "MIC BIAS External1";
 };
 
 &usb {

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprimeltecan.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprimeltecan.dts
@@ -27,3 +27,42 @@
 		};
 	};
 };
+
+&blsp_i2c2 {
+	status = "okay";
+
+	accelerometer: accelerometer@10 {
+		compatible = "bosch,bmc150_accel";
+		reg = <0x10>;
+		interrupt-parent = <&msmgpio>;
+		interrupts = <115 IRQ_TYPE_EDGE_RISING>;
+
+		vdd-supply = <&pm8916_l17>;
+		vddio-supply = <&pm8916_l5>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&accel_int_default>;
+
+		mount-matrix = "0", "-1", "0",
+			       "-1", "0", "0",
+			       "0", "0", "1";
+	};
+
+	magnetometer@12 {
+		compatible = "bosch,bmc150_magn";
+		reg = <0x12>;
+
+		vdd-supply = <&pm8916_l17>;
+		vddio-supply = <&pm8916_l5>;
+	};
+};
+
+&msmgpio {
+	accel_int_default: accel-int-default {
+		pins = "gpio115";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+};

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprimeltecan.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprimeltecan.dts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include "msm8916-samsung-gprime-common.dtsi"
+
+/ {
+	model = "Samsung Galaxy Grand Prime (CAN)";
+	compatible = "samsung,gprimeltecan", "qcom,msm8916";
+	chassis-type = "handset";
+
+	reserved-memory {
+		/* Additional memory used by Samsung firmware modifications */
+		tz-apps@85500000 {
+			reg = <0x0 0x85500000 0x0 0xb00000>;
+			no-map;
+		};
+
+		mpss_mem: mpss@86800000 {
+			reg = <0x0 0x86800000 0x0 0x5800000>;
+			no-map;
+		};
+
+		gps_mem: gps@8c000000 {
+			reg = <0x0 0x8c000000 0x0 0x200000>;
+			no-map;
+		};
+	};
+};

--- a/drivers/gpu/drm/panel/msm8916-generated/Makefile
+++ b/drivers/gpu/drm/panel/msm8916-generated/Makefile
@@ -1,6 +1,7 @@
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-alcatel-auo-hx8394d.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-asus-z00l-otm1284a.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-asus-z010d-r69339.o
+obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-huawei-boe-otm8019a.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-huawei-tianma-nt35521.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-longcheer-booyi-otm1287.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-longcheer-dijing-ili9881c.o
@@ -12,7 +13,9 @@ obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-motorola-osprey-inx.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-motorola-surnia-boe.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-oppo-15009-nt35592-jdi.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-ea8061v-ams497ee01.o
+obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-hx8389c.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-nt51017-b4p096wx5vp09.o
+obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-s6d78a0-gh9607501a.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-s6d7aa0-lsl080al03.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-s6d7aa0-ltl101at01.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-s6e88a0-ams427ap24.o

--- a/drivers/gpu/drm/panel/msm8916-generated/Makefile
+++ b/drivers/gpu/drm/panel/msm8916-generated/Makefile
@@ -13,6 +13,7 @@ obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-motorola-osprey-inx.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-motorola-surnia-boe.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-oppo-15009-nt35592-jdi.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-ea8061v-ams497ee01.o
+obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-hx8389c-gh9607501a.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-hx8389c.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-nt51017-b4p096wx5vp09.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-s6d78a0-gh9607501a.o

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-alcatel-auo-hx8394d.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-alcatel-auo-hx8394d.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-asus-z00l-otm1284a.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-asus-z00l-otm1284a.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-asus-z010d-r69339.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-asus-z010d-r69339.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-huawei-boe-otm8019a.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-huawei-boe-otm8019a.c
@@ -1,0 +1,497 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2022 FIXME
+// Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
+//   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
+
+#include <linux/backlight.h>
+#include <linux/delay.h>
+#include <linux/gpio/consumer.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/regulator/consumer.h>
+
+#include <video/mipi_display.h>
+
+#include <drm/drm_mipi_dsi.h>
+#include <drm/drm_modes.h>
+#include <drm/drm_panel.h>
+
+struct boe_otm8019a_5p0 {
+	struct drm_panel panel;
+	struct mipi_dsi_device *dsi;
+	struct regulator *supply;
+	struct gpio_desc *reset_gpio;
+	bool prepared;
+};
+
+static inline
+struct boe_otm8019a_5p0 *to_boe_otm8019a_5p0(struct drm_panel *panel)
+{
+	return container_of(panel, struct boe_otm8019a_5p0, panel);
+}
+
+#define dsi_generic_write_seq(dsi, seq...) do {				\
+		static const u8 d[] = { seq };				\
+		int ret;						\
+		ret = mipi_dsi_generic_write(dsi, d, ARRAY_SIZE(d));	\
+		if (ret < 0)						\
+			return ret;					\
+	} while (0)
+
+#define dsi_dcs_write_seq(dsi, seq...) do {				\
+		static const u8 d[] = { seq };				\
+		int ret;						\
+		ret = mipi_dsi_dcs_write_buffer(dsi, d, ARRAY_SIZE(d));	\
+		if (ret < 0)						\
+			return ret;					\
+	} while (0)
+
+static void boe_otm8019a_5p0_reset(struct boe_otm8019a_5p0 *ctx)
+{
+	gpiod_set_value_cansleep(ctx->reset_gpio, 0);
+	usleep_range(1000, 2000);
+	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+	msleep(20);
+	gpiod_set_value_cansleep(ctx->reset_gpio, 0);
+	msleep(120);
+}
+
+static int boe_otm8019a_5p0_on(struct boe_otm8019a_5p0 *ctx)
+{
+	struct mipi_dsi_device *dsi = ctx->dsi;
+	struct device *dev = &dsi->dev;
+	int ret;
+
+	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+
+	dsi_generic_write_seq(dsi, 0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0xff, 0x80, 0x19, 0x01);
+	dsi_generic_write_seq(dsi, 0x00, 0x80);
+	dsi_generic_write_seq(dsi, 0xff, 0x80, 0x19);
+	dsi_generic_write_seq(dsi, 0x00, 0x03);
+	dsi_generic_write_seq(dsi, 0xff, 0x01);
+	dsi_generic_write_seq(dsi, 0x00, 0x90);
+	dsi_generic_write_seq(dsi, 0xb3, 0x02);
+	dsi_generic_write_seq(dsi, 0x00, 0x92);
+	dsi_generic_write_seq(dsi, 0xb3, 0x45);
+	dsi_generic_write_seq(dsi, 0x00, 0xa2);
+	dsi_generic_write_seq(dsi, 0xc0, 0x00, 0x1b);
+	dsi_generic_write_seq(dsi, 0x00, 0x80);
+	dsi_generic_write_seq(dsi, 0xc0,
+			      0x00, 0x58, 0x00, 0x14, 0x16, 0x00, 0x58, 0x14,
+			      0x16);
+	dsi_generic_write_seq(dsi, 0x00, 0xb4);
+	dsi_generic_write_seq(dsi, 0xc0, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xb5);
+	dsi_generic_write_seq(dsi, 0xc0, 0x18);
+	dsi_generic_write_seq(dsi, 0x00, 0x81);
+	dsi_generic_write_seq(dsi, 0xc4, 0x04);
+	dsi_generic_write_seq(dsi, 0x00, 0x8a);
+	dsi_generic_write_seq(dsi, 0xc4, 0x40);
+	dsi_generic_write_seq(dsi, 0x00, 0x80);
+	dsi_generic_write_seq(dsi, 0xc1, 0x03);
+	dsi_generic_write_seq(dsi, 0x00, 0x90);
+	dsi_generic_write_seq(dsi, 0xc0, 0x00, 0x15, 0x00, 0x00, 0x00, 0x03);
+	dsi_generic_write_seq(dsi, 0x00, 0x80);
+	dsi_generic_write_seq(dsi, 0xc4, 0x30);
+	dsi_generic_write_seq(dsi, 0x00, 0xa0);
+	dsi_generic_write_seq(dsi, 0xc1, 0xe8);
+	dsi_generic_write_seq(dsi, 0x00, 0x98);
+	dsi_generic_write_seq(dsi, 0xc0, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xa9);
+	dsi_generic_write_seq(dsi, 0xc0, 0x0a);
+	dsi_generic_write_seq(dsi, 0x00, 0xb0);
+	dsi_generic_write_seq(dsi, 0xc1, 0x20, 0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xe1);
+	dsi_generic_write_seq(dsi, 0xc0, 0x40, 0x30);
+	dsi_generic_write_seq(dsi, 0x00, 0x90);
+	dsi_generic_write_seq(dsi, 0xb6, 0xb4);
+	dsi_generic_write_seq(dsi, 0x00, 0x87);
+	dsi_generic_write_seq(dsi, 0xc4, 0x18);
+	dsi_generic_write_seq(dsi, 0x00, 0x89);
+	dsi_generic_write_seq(dsi, 0xc4, 0x08);
+	dsi_generic_write_seq(dsi, 0x00, 0x82);
+	dsi_generic_write_seq(dsi, 0xc5, 0x03);
+	dsi_generic_write_seq(dsi, 0x00, 0x90);
+	dsi_generic_write_seq(dsi, 0xc5, 0x4e, 0x29, 0x00, 0x7b, 0x44);
+	dsi_generic_write_seq(dsi, 0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0xd8, 0x5f);
+	dsi_generic_write_seq(dsi, 0x00, 0x01);
+	dsi_generic_write_seq(dsi, 0xd8, 0x5f);
+	dsi_generic_write_seq(dsi, 0x00, 0x81);
+	dsi_generic_write_seq(dsi, 0xc1, 0x03);
+	dsi_generic_write_seq(dsi, 0x00, 0xa1);
+	dsi_generic_write_seq(dsi, 0xc1, 0x08);
+	dsi_generic_write_seq(dsi, 0x00, 0xb1);
+	dsi_generic_write_seq(dsi, 0xc5, 0x29);
+	dsi_generic_write_seq(dsi, 0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0xe1,
+			      0x1c, 0x2a, 0x34, 0x40, 0x4d, 0x5c, 0x5c, 0x82,
+			      0x73, 0x8b, 0x7a, 0x65, 0x77, 0x55, 0x52, 0x41,
+			      0x34, 0x29, 0x23, 0x1f);
+	dsi_generic_write_seq(dsi, 0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0xe2,
+			      0x1c, 0x2a, 0x34, 0x40, 0x4d, 0x5c, 0x5c, 0x82,
+			      0x73, 0x8b, 0x7a, 0x65, 0x77, 0x55, 0x52, 0x41,
+			      0x34, 0x29, 0x23, 0x1f);
+	dsi_generic_write_seq(dsi, 0x00, 0x80);
+	dsi_generic_write_seq(dsi, 0xce,
+			      0x86, 0x01, 0x00, 0x85, 0x01, 0x00, 0x00, 0x00,
+			      0x00, 0x00, 0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xa0);
+	dsi_generic_write_seq(dsi, 0xce,
+			      0x18, 0x05, 0x83, 0x5a, 0x86, 0x04, 0x00, 0x18,
+			      0x04, 0x83, 0x5b, 0x86, 0x04, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xb0);
+	dsi_generic_write_seq(dsi, 0xce,
+			      0x18, 0x03, 0x83, 0x5c, 0x86, 0x04, 0x00, 0x18,
+			      0x02, 0x83, 0x5d, 0x86, 0x04, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xc0);
+	dsi_generic_write_seq(dsi, 0xcf,
+			      0x01, 0x01, 0x20, 0x20, 0x00, 0x00, 0x01, 0x01,
+			      0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xd0);
+	dsi_generic_write_seq(dsi, 0xcf, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0x80);
+	dsi_generic_write_seq(dsi, 0xcb,
+			      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			      0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0x90);
+	dsi_generic_write_seq(dsi, 0xcb,
+			      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xa0);
+	dsi_generic_write_seq(dsi, 0xcb,
+			      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xb0);
+	dsi_generic_write_seq(dsi, 0xcb,
+			      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			      0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xc0);
+	dsi_generic_write_seq(dsi, 0xcb,
+			      0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00,
+			      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xd0);
+	dsi_generic_write_seq(dsi, 0xcb,
+			      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xe0);
+	dsi_generic_write_seq(dsi, 0xcb,
+			      0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x00, 0x00,
+			      0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xf0);
+	dsi_generic_write_seq(dsi, 0xcb,
+			      0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+			      0xff, 0xff);
+	dsi_generic_write_seq(dsi, 0x00, 0x80);
+	dsi_generic_write_seq(dsi, 0xcc,
+			      0x00, 0x26, 0x09, 0x0b, 0x01, 0x25, 0x00, 0x00,
+			      0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0x90);
+	dsi_generic_write_seq(dsi, 0xcc,
+			      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xa0);
+	dsi_generic_write_seq(dsi, 0xcc,
+			      0x00, 0x00, 0x00, 0x00, 0x00, 0x25, 0x02, 0x0c,
+			      0x0a, 0x26, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xb0);
+	dsi_generic_write_seq(dsi, 0xcc,
+			      0x00, 0x25, 0x0a, 0x0c, 0x02, 0x26, 0x00, 0x00,
+			      0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xc0);
+	dsi_generic_write_seq(dsi, 0xcc,
+			      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xd0);
+	dsi_generic_write_seq(dsi, 0xcc,
+			      0x00, 0x00, 0x00, 0x00, 0x00, 0x26, 0x01, 0x0b,
+			      0x09, 0x25, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0x00, 0xb0);
+	dsi_generic_write_seq(dsi, 0xca, 0x09);
+	dsi_generic_write_seq(dsi, 0x00, 0xb3);
+	dsi_generic_write_seq(dsi, 0xca, 0x50);
+	dsi_generic_write_seq(dsi, 0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0xfb, 0x00);
+	msleep(50);
+	dsi_generic_write_seq(dsi, 0x00, 0x00);
+	dsi_generic_write_seq(dsi, 0xff, 0xff, 0xff, 0xff);
+
+	ret = mipi_dsi_dcs_set_display_brightness(dsi, 0x0000);
+	if (ret < 0) {
+		dev_err(dev, "Failed to set display brightness: %d\n", ret);
+		return ret;
+	}
+
+	dsi_dcs_write_seq(dsi, MIPI_DCS_WRITE_CONTROL_DISPLAY, 0x24);
+	dsi_dcs_write_seq(dsi, MIPI_DCS_WRITE_POWER_SAVE, 0x01);
+	dsi_dcs_write_seq(dsi, MIPI_DCS_SET_CABC_MIN_BRIGHTNESS, 0x28);
+
+	ret = mipi_dsi_dcs_exit_sleep_mode(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to exit sleep mode: %d\n", ret);
+		return ret;
+	}
+	msleep(120);
+
+	ret = mipi_dsi_dcs_set_display_on(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to set display on: %d\n", ret);
+		return ret;
+	}
+	msleep(20);
+
+	return 0;
+}
+
+static int boe_otm8019a_5p0_off(struct boe_otm8019a_5p0 *ctx)
+{
+	struct mipi_dsi_device *dsi = ctx->dsi;
+	struct device *dev = &dsi->dev;
+	int ret;
+
+	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
+
+	ret = mipi_dsi_dcs_set_display_off(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to set display off: %d\n", ret);
+		return ret;
+	}
+	msleep(20);
+
+	ret = mipi_dsi_dcs_enter_sleep_mode(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to enter sleep mode: %d\n", ret);
+		return ret;
+	}
+	msleep(120);
+
+	return 0;
+}
+
+static int boe_otm8019a_5p0_prepare(struct drm_panel *panel)
+{
+	struct boe_otm8019a_5p0 *ctx = to_boe_otm8019a_5p0(panel);
+	struct device *dev = &ctx->dsi->dev;
+	int ret;
+
+	if (ctx->prepared)
+		return 0;
+
+	ret = regulator_enable(ctx->supply);
+	if (ret < 0) {
+		dev_err(dev, "Failed to enable regulator: %d\n", ret);
+		return ret;
+	}
+
+	boe_otm8019a_5p0_reset(ctx);
+
+	ret = boe_otm8019a_5p0_on(ctx);
+	if (ret < 0) {
+		dev_err(dev, "Failed to initialize panel: %d\n", ret);
+		gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+		regulator_disable(ctx->supply);
+		return ret;
+	}
+
+	ctx->prepared = true;
+	return 0;
+}
+
+static int boe_otm8019a_5p0_unprepare(struct drm_panel *panel)
+{
+	struct boe_otm8019a_5p0 *ctx = to_boe_otm8019a_5p0(panel);
+	struct device *dev = &ctx->dsi->dev;
+	int ret;
+
+	if (!ctx->prepared)
+		return 0;
+
+	ret = boe_otm8019a_5p0_off(ctx);
+	if (ret < 0)
+		dev_err(dev, "Failed to un-initialize panel: %d\n", ret);
+
+	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+	regulator_disable(ctx->supply);
+
+	ctx->prepared = false;
+	return 0;
+}
+
+static const struct drm_display_mode boe_otm8019a_5p0_mode = {
+	.clock = (480 + 92 + 12 + 88) * (854 + 18 + 4 + 18) * 60 / 1000,
+	.hdisplay = 480,
+	.hsync_start = 480 + 92,
+	.hsync_end = 480 + 92 + 12,
+	.htotal = 480 + 92 + 12 + 88,
+	.vdisplay = 854,
+	.vsync_start = 854 + 18,
+	.vsync_end = 854 + 18 + 4,
+	.vtotal = 854 + 18 + 4 + 18,
+	.width_mm = 62,
+	.height_mm = 110,
+};
+
+static int boe_otm8019a_5p0_get_modes(struct drm_panel *panel,
+				      struct drm_connector *connector)
+{
+	struct drm_display_mode *mode;
+
+	mode = drm_mode_duplicate(connector->dev, &boe_otm8019a_5p0_mode);
+	if (!mode)
+		return -ENOMEM;
+
+	drm_mode_set_name(mode);
+
+	mode->type = DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED;
+	connector->display_info.width_mm = mode->width_mm;
+	connector->display_info.height_mm = mode->height_mm;
+	drm_mode_probed_add(connector, mode);
+
+	return 1;
+}
+
+static const struct drm_panel_funcs boe_otm8019a_5p0_panel_funcs = {
+	.prepare = boe_otm8019a_5p0_prepare,
+	.unprepare = boe_otm8019a_5p0_unprepare,
+	.get_modes = boe_otm8019a_5p0_get_modes,
+};
+
+static int boe_otm8019a_5p0_bl_update_status(struct backlight_device *bl)
+{
+	struct mipi_dsi_device *dsi = bl_get_data(bl);
+	u16 brightness = backlight_get_brightness(bl);
+	int ret;
+
+	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
+
+	ret = mipi_dsi_dcs_set_display_brightness(dsi, brightness);
+	if (ret < 0)
+		return ret;
+
+	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+
+	return 0;
+}
+
+// TODO: Check if /sys/class/backlight/.../actual_brightness actually returns
+// correct values. If not, remove this function.
+static int boe_otm8019a_5p0_bl_get_brightness(struct backlight_device *bl)
+{
+	struct mipi_dsi_device *dsi = bl_get_data(bl);
+	u16 brightness;
+	int ret;
+
+	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
+
+	ret = mipi_dsi_dcs_get_display_brightness(dsi, &brightness);
+	if (ret < 0)
+		return ret;
+
+	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+
+	return brightness & 0xff;
+}
+
+static const struct backlight_ops boe_otm8019a_5p0_bl_ops = {
+	.update_status = boe_otm8019a_5p0_bl_update_status,
+	.get_brightness = boe_otm8019a_5p0_bl_get_brightness,
+};
+
+static struct backlight_device *
+boe_otm8019a_5p0_create_backlight(struct mipi_dsi_device *dsi)
+{
+	struct device *dev = &dsi->dev;
+	const struct backlight_properties props = {
+		.type = BACKLIGHT_RAW,
+		.brightness = 250,
+		.max_brightness = 250,
+	};
+
+	return devm_backlight_device_register(dev, dev_name(dev), dev, dsi,
+					      &boe_otm8019a_5p0_bl_ops, &props);
+}
+
+static int boe_otm8019a_5p0_probe(struct mipi_dsi_device *dsi)
+{
+	struct device *dev = &dsi->dev;
+	struct boe_otm8019a_5p0 *ctx;
+	int ret;
+
+	ctx = devm_kzalloc(dev, sizeof(*ctx), GFP_KERNEL);
+	if (!ctx)
+		return -ENOMEM;
+
+	ctx->supply = devm_regulator_get(dev, "power");
+	if (IS_ERR(ctx->supply))
+		return dev_err_probe(dev, PTR_ERR(ctx->supply),
+				     "Failed to get power regulator\n");
+
+	ctx->reset_gpio = devm_gpiod_get(dev, "reset", GPIOD_OUT_HIGH);
+	if (IS_ERR(ctx->reset_gpio))
+		return dev_err_probe(dev, PTR_ERR(ctx->reset_gpio),
+				     "Failed to get reset-gpios\n");
+
+	ctx->dsi = dsi;
+	mipi_dsi_set_drvdata(dsi, ctx);
+
+	dsi->lanes = 2;
+	dsi->format = MIPI_DSI_FMT_RGB888;
+	dsi->mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST |
+			  MIPI_DSI_MODE_VIDEO_HSE | MIPI_DSI_MODE_NO_EOT_PACKET |
+			  MIPI_DSI_CLOCK_NON_CONTINUOUS;
+
+	drm_panel_init(&ctx->panel, dev, &boe_otm8019a_5p0_panel_funcs,
+		       DRM_MODE_CONNECTOR_DSI);
+
+	ctx->panel.backlight = boe_otm8019a_5p0_create_backlight(dsi);
+	if (IS_ERR(ctx->panel.backlight))
+		return dev_err_probe(dev, PTR_ERR(ctx->panel.backlight),
+				     "Failed to create backlight\n");
+
+	drm_panel_add(&ctx->panel);
+
+	ret = mipi_dsi_attach(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to attach to DSI host: %d\n", ret);
+		drm_panel_remove(&ctx->panel);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int boe_otm8019a_5p0_remove(struct mipi_dsi_device *dsi)
+{
+	struct boe_otm8019a_5p0 *ctx = mipi_dsi_get_drvdata(dsi);
+	int ret;
+
+	ret = mipi_dsi_detach(dsi);
+	if (ret < 0)
+		dev_err(&dsi->dev, "Failed to detach from DSI host: %d\n", ret);
+
+	drm_panel_remove(&ctx->panel);
+
+	return 0;
+}
+
+static const struct of_device_id boe_otm8019a_5p0_of_match[] = {
+	{ .compatible = "huawei,boe-otm8019a" }, // FIXME
+	{ /* sentinel */ }
+};
+MODULE_DEVICE_TABLE(of, boe_otm8019a_5p0_of_match);
+
+static struct mipi_dsi_driver boe_otm8019a_5p0_driver = {
+	.probe = boe_otm8019a_5p0_probe,
+	.remove = boe_otm8019a_5p0_remove,
+	.driver = {
+		.name = "panel-boe-otm8019a-5p0",
+		.of_match_table = boe_otm8019a_5p0_of_match,
+	},
+};
+module_mipi_dsi_driver(boe_otm8019a_5p0_driver);
+
+MODULE_AUTHOR("linux-mdss-dsi-panel-driver-generator <fix@me>"); // FIXME
+MODULE_DESCRIPTION("DRM driver for BOE_OTM8019A_5P0_FWVGA_VIDEO");
+MODULE_LICENSE("GPL v2");

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-huawei-tianma-nt35521.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-huawei-tianma-nt35521.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-longcheer-booyi-otm1287.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-longcheer-booyi-otm1287.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-longcheer-dijing-ili9881c.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-longcheer-dijing-ili9881c.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-motorola-harpia-boe.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-motorola-harpia-boe.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-motorola-osprey-inx.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-motorola-osprey-inx.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-motorola-surnia-boe.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-motorola-surnia-boe.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-ea8061v-ams497ee01.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-ea8061v-ams497ee01.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-hx8389c-gh9607501a.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-hx8389c-gh9607501a.c
@@ -1,0 +1,332 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2022 FIXME
+// Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
+//   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
+
+#include <linux/delay.h>
+#include <linux/gpio/consumer.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/regulator/consumer.h>
+
+#include <video/mipi_display.h>
+
+#include <drm/drm_mipi_dsi.h>
+#include <drm/drm_modes.h>
+#include <drm/drm_panel.h>
+
+struct hx8389c_gh9607501a {
+	struct drm_panel panel;
+	struct mipi_dsi_device *dsi;
+	struct regulator_bulk_data supplies[2];
+	struct gpio_desc *reset_gpio;
+	bool prepared;
+};
+
+static inline
+struct hx8389c_gh9607501a *to_hx8389c_gh9607501a(struct drm_panel *panel)
+{
+	return container_of(panel, struct hx8389c_gh9607501a, panel);
+}
+
+#define dsi_dcs_write_seq(dsi, seq...) do {				\
+		static const u8 d[] = { seq };				\
+		int ret;						\
+		ret = mipi_dsi_dcs_write_buffer(dsi, d, ARRAY_SIZE(d));	\
+		if (ret < 0)						\
+			return ret;					\
+	} while (0)
+
+static void hx8389c_gh9607501a_reset(struct hx8389c_gh9607501a *ctx)
+{
+	gpiod_set_value_cansleep(ctx->reset_gpio, 0);
+	usleep_range(10000, 11000);
+	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+	usleep_range(2000, 3000);
+	gpiod_set_value_cansleep(ctx->reset_gpio, 0);
+	msleep(80);
+}
+
+static int hx8389c_gh9607501a_on(struct hx8389c_gh9607501a *ctx)
+{
+	struct mipi_dsi_device *dsi = ctx->dsi;
+	struct device *dev = &dsi->dev;
+	int ret;
+
+	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+
+	dsi_dcs_write_seq(dsi, 0xb9, 0xff, 0x83, 0x89);
+	usleep_range(10000, 11000);
+	dsi_dcs_write_seq(dsi, 0xb1,
+			  0x7f, 0x10, 0x10, 0xd2, 0x32, 0x80, 0x10, 0xf0, 0x56,
+			  0x80, 0x20, 0x20, 0xf8, 0xaa, 0xaa, 0xa1, 0x00, 0x80,
+			  0x30, 0x00);
+	dsi_dcs_write_seq(dsi, 0xb2,
+			  0x82, 0x50, 0x05, 0x07, 0xf0, 0x38, 0x11, 0x64, 0x5d,
+			  0x09);
+	dsi_dcs_write_seq(dsi, 0xb4,
+			  0x66, 0x66, 0x66, 0x70, 0x00, 0x00, 0x18, 0x76, 0x28,
+			  0x76, 0xa8);
+	dsi_dcs_write_seq(dsi, 0xd2, 0x33);
+	dsi_dcs_write_seq(dsi, 0xc0, 0x30, 0x17, 0x00, 0x03);
+	dsi_dcs_write_seq(dsi, 0xc7, 0x00, 0x80, 0x00, 0xc0);
+	dsi_dcs_write_seq(dsi, 0xbf, 0x05, 0x50, 0x00, 0x3e);
+	usleep_range(10000, 11000);
+	dsi_dcs_write_seq(dsi, 0xb9, 0xff, 0x83, 0x89);
+	dsi_dcs_write_seq(dsi, 0xcc, 0x0e);
+	dsi_dcs_write_seq(dsi, 0xd3,
+			  0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x32, 0x10,
+			  0x00, 0x00, 0x00, 0x03, 0xc6, 0x03, 0xc6, 0x00, 0x00,
+			  0x00, 0x00, 0x35, 0x33, 0x04, 0x04, 0x37, 0x00, 0x00,
+			  0x00, 0x05, 0x08, 0x00, 0x00, 0x0a, 0x00, 0x01);
+	dsi_dcs_write_seq(dsi, 0xd5,
+			  0x18, 0x18, 0x18, 0x18, 0x19, 0x19, 0x18, 0x18, 0x20,
+			  0x21, 0x24, 0x25, 0x18, 0x18, 0x18, 0x18, 0x00, 0x01,
+			  0x04, 0x05, 0x02, 0x03, 0x06, 0x07, 0x18, 0x18, 0x18,
+			  0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18,
+			  0x18, 0x18);
+	dsi_dcs_write_seq(dsi, 0xd6,
+			  0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x19, 0x19, 0x25,
+			  0x24, 0x21, 0x20, 0x18, 0x18, 0x18, 0x18, 0x07, 0x06,
+			  0x03, 0x02, 0x05, 0x04, 0x01, 0x00, 0x18, 0x18, 0x18,
+			  0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18,
+			  0x18, 0x18);
+	dsi_dcs_write_seq(dsi, 0xb7, 0x20, 0x80, 0x00);
+	dsi_dcs_write_seq(dsi, 0xe0,
+			  0x00, 0x02, 0x06, 0x38, 0x3c, 0x3f, 0x1b, 0x46, 0x06,
+			  0x09, 0x0c, 0x17, 0x10, 0x13, 0x16, 0x13, 0x14, 0x08,
+			  0x13, 0x15, 0x19, 0x00, 0x02, 0x06, 0x37, 0x3c, 0x3f,
+			  0x1a, 0x45, 0x05, 0x09, 0x0b, 0x16, 0x0f, 0x13, 0x15,
+			  0x13, 0x14, 0x07, 0x12, 0x14, 0x18);
+	dsi_dcs_write_seq(dsi, 0xbd, 0x00);
+	dsi_dcs_write_seq(dsi, 0xc1,
+			  0x00, 0x00, 0x08, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38,
+			  0x40, 0x48, 0x50, 0x58, 0x60, 0x68, 0x70, 0x78, 0x80,
+			  0x88, 0x90, 0x98, 0xa0, 0xa8, 0xb0, 0xb8, 0xc0, 0xc8,
+			  0xd0, 0xd8, 0xe0, 0xe8, 0xf0, 0xf8, 0xff, 0x00, 0x00,
+			  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_dcs_write_seq(dsi, 0xbd, 0x01);
+	dsi_dcs_write_seq(dsi, 0xc1,
+			  0x00, 0x08, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38, 0x40,
+			  0x48, 0x50, 0x58, 0x60, 0x68, 0x70, 0x78, 0x80, 0x88,
+			  0x90, 0x98, 0xa0, 0xa8, 0xb0, 0xb8, 0xc0, 0xc8, 0xd0,
+			  0xd8, 0xe0, 0xe8, 0xf0, 0xf8, 0xff, 0x00, 0x00, 0x00,
+			  0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_dcs_write_seq(dsi, 0xbd, 0x02);
+	dsi_dcs_write_seq(dsi, 0xc1,
+			  0x00, 0x08, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38, 0x40,
+			  0x48, 0x50, 0x58, 0x60, 0x68, 0x70, 0x78, 0x80, 0x88,
+			  0x90, 0x98, 0xa0, 0xa8, 0xb0, 0xb8, 0xc0, 0xc8, 0xd0,
+			  0xd8, 0xe0, 0xe8, 0xf0, 0xf8, 0xff, 0x00, 0x00, 0x00,
+			  0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_dcs_write_seq(dsi, 0xc9,
+			  0x1f, 0x00, 0x0f, 0x1e, 0x81, 0x1e, 0x00, 0x00, 0x01,
+			  0x19, 0x00, 0x00, 0x20);
+	usleep_range(5000, 6000);
+	dsi_dcs_write_seq(dsi, MIPI_DCS_WRITE_POWER_SAVE, 0x00);
+	usleep_range(5000, 6000);
+	dsi_dcs_write_seq(dsi, MIPI_DCS_WRITE_CONTROL_DISPLAY, 0x24);
+	usleep_range(5000, 6000);
+
+	ret = mipi_dsi_dcs_exit_sleep_mode(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to exit sleep mode: %d\n", ret);
+		return ret;
+	}
+	msleep(125);
+
+	ret = mipi_dsi_dcs_set_display_on(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to set display on: %d\n", ret);
+		return ret;
+	}
+	usleep_range(5000, 6000);
+
+	return 0;
+}
+
+static int hx8389c_gh9607501a_off(struct hx8389c_gh9607501a *ctx)
+{
+	struct mipi_dsi_device *dsi = ctx->dsi;
+
+	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
+
+	dsi_dcs_write_seq(dsi, 0x28, 0x00);
+	msleep(60);
+	dsi_dcs_write_seq(dsi, 0x10, 0x00);
+	msleep(60);
+
+	return 0;
+}
+
+static int hx8389c_gh9607501a_prepare(struct drm_panel *panel)
+{
+	struct hx8389c_gh9607501a *ctx = to_hx8389c_gh9607501a(panel);
+	struct device *dev = &ctx->dsi->dev;
+	int ret;
+
+	if (ctx->prepared)
+		return 0;
+
+	ret = regulator_bulk_enable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+	if (ret < 0) {
+		dev_err(dev, "Failed to enable regulators: %d\n", ret);
+		return ret;
+	}
+
+	hx8389c_gh9607501a_reset(ctx);
+
+	ret = hx8389c_gh9607501a_on(ctx);
+	if (ret < 0) {
+		dev_err(dev, "Failed to initialize panel: %d\n", ret);
+		gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+		regulator_bulk_disable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+		return ret;
+	}
+
+	ctx->prepared = true;
+	return 0;
+}
+
+static int hx8389c_gh9607501a_unprepare(struct drm_panel *panel)
+{
+	struct hx8389c_gh9607501a *ctx = to_hx8389c_gh9607501a(panel);
+	struct device *dev = &ctx->dsi->dev;
+	int ret;
+
+	if (!ctx->prepared)
+		return 0;
+
+	ret = hx8389c_gh9607501a_off(ctx);
+	if (ret < 0)
+		dev_err(dev, "Failed to un-initialize panel: %d\n", ret);
+
+	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+	regulator_bulk_disable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+
+	ctx->prepared = false;
+	return 0;
+}
+
+static const struct drm_display_mode hx8389c_gh9607501a_mode = {
+	.clock = (540 + 10 + 14 + 10) * (960 + 9 + 2 + 5) * 60 / 1000,
+	.hdisplay = 540,
+	.hsync_start = 540 + 10,
+	.hsync_end = 540 + 10 + 14,
+	.htotal = 540 + 10 + 14 + 10,
+	.vdisplay = 960,
+	.vsync_start = 960 + 9,
+	.vsync_end = 960 + 9 + 2,
+	.vtotal = 960 + 9 + 2 + 5,
+	.width_mm = 62,
+	.height_mm = 110,
+};
+
+static int hx8389c_gh9607501a_get_modes(struct drm_panel *panel,
+					struct drm_connector *connector)
+{
+	struct drm_display_mode *mode;
+
+	mode = drm_mode_duplicate(connector->dev, &hx8389c_gh9607501a_mode);
+	if (!mode)
+		return -ENOMEM;
+
+	drm_mode_set_name(mode);
+
+	mode->type = DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED;
+	connector->display_info.width_mm = mode->width_mm;
+	connector->display_info.height_mm = mode->height_mm;
+	drm_mode_probed_add(connector, mode);
+
+	return 1;
+}
+
+static const struct drm_panel_funcs hx8389c_gh9607501a_panel_funcs = {
+	.prepare = hx8389c_gh9607501a_prepare,
+	.unprepare = hx8389c_gh9607501a_unprepare,
+	.get_modes = hx8389c_gh9607501a_get_modes,
+};
+
+static int hx8389c_gh9607501a_probe(struct mipi_dsi_device *dsi)
+{
+	struct device *dev = &dsi->dev;
+	struct hx8389c_gh9607501a *ctx;
+	int ret;
+
+	ctx = devm_kzalloc(dev, sizeof(*ctx), GFP_KERNEL);
+	if (!ctx)
+		return -ENOMEM;
+
+	ctx->supplies[0].supply = "vreg";
+	ctx->supplies[1].supply = "vdd";
+	ret = devm_regulator_bulk_get(dev, ARRAY_SIZE(ctx->supplies),
+				      ctx->supplies);
+	if (ret < 0)
+		return dev_err_probe(dev, ret, "Failed to get regulators\n");
+
+	ctx->reset_gpio = devm_gpiod_get(dev, "reset", GPIOD_OUT_HIGH);
+	if (IS_ERR(ctx->reset_gpio))
+		return dev_err_probe(dev, PTR_ERR(ctx->reset_gpio),
+				     "Failed to get reset-gpios\n");
+
+	ctx->dsi = dsi;
+	mipi_dsi_set_drvdata(dsi, ctx);
+
+	dsi->lanes = 2;
+	dsi->format = MIPI_DSI_FMT_RGB888;
+	dsi->mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_SYNC_PULSE |
+			  MIPI_DSI_MODE_NO_EOT_PACKET |
+			  MIPI_DSI_CLOCK_NON_CONTINUOUS;
+
+	drm_panel_init(&ctx->panel, dev, &hx8389c_gh9607501a_panel_funcs,
+		       DRM_MODE_CONNECTOR_DSI);
+
+	ret = drm_panel_of_backlight(&ctx->panel);
+	if (ret)
+		return dev_err_probe(dev, ret, "Failed to get backlight\n");
+
+	drm_panel_add(&ctx->panel);
+
+	ret = mipi_dsi_attach(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to attach to DSI host: %d\n", ret);
+		drm_panel_remove(&ctx->panel);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int hx8389c_gh9607501a_remove(struct mipi_dsi_device *dsi)
+{
+	struct hx8389c_gh9607501a *ctx = mipi_dsi_get_drvdata(dsi);
+	int ret;
+
+	ret = mipi_dsi_detach(dsi);
+	if (ret < 0)
+		dev_err(&dsi->dev, "Failed to detach from DSI host: %d\n", ret);
+
+	drm_panel_remove(&ctx->panel);
+
+	return 0;
+}
+
+static const struct of_device_id hx8389c_gh9607501a_of_match[] = {
+	{ .compatible = "samsung,hx8389c-gh9607501a" }, // FIXME
+	{ /* sentinel */ }
+};
+MODULE_DEVICE_TABLE(of, hx8389c_gh9607501a_of_match);
+
+static struct mipi_dsi_driver hx8389c_gh9607501a_driver = {
+	.probe = hx8389c_gh9607501a_probe,
+	.remove = hx8389c_gh9607501a_remove,
+	.driver = {
+		.name = "panel-hx8389c-gh9607501a",
+		.of_match_table = hx8389c_gh9607501a_of_match,
+	},
+};
+module_mipi_dsi_driver(hx8389c_gh9607501a_driver);
+
+MODULE_AUTHOR("linux-mdss-dsi-panel-driver-generator <fix@me>"); // FIXME
+MODULE_DESCRIPTION("DRM driver for HX8389C qhd video mode dsi panel");
+MODULE_LICENSE("GPL v2");

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-hx8389c-gh9607501a.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-hx8389c-gh9607501a.c
@@ -3,6 +3,7 @@
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 
+#include <linux/backlight.h>
 #include <linux/delay.h>
 #include <linux/gpio/consumer.h>
 #include <linux/module.h>
@@ -247,6 +248,49 @@ static const struct drm_panel_funcs hx8389c_gh9607501a_panel_funcs = {
 	.get_modes = hx8389c_gh9607501a_get_modes,
 };
 
+static int hx8389c_gh9607501a_bl_update_status(struct backlight_device *bl)
+{
+	struct mipi_dsi_device *dsi = bl_get_data(bl);
+	u16 brightness = backlight_get_brightness(bl);
+	int ret;
+	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
+	ret = mipi_dsi_dcs_set_display_brightness(dsi, brightness);
+	if (ret < 0)
+		return ret;
+	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+	return 0;
+}
+// TODO: Check if /sys/class/backlight/.../actual_brightness actually returns
+// correct values. If not, remove this function.
+static int hx8389c_gh9607501a_bl_get_brightness(struct backlight_device *bl)
+{
+	struct mipi_dsi_device *dsi = bl_get_data(bl);
+	u16 brightness;
+	int ret;
+	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
+	ret = mipi_dsi_dcs_get_display_brightness(dsi, &brightness);
+	if (ret < 0)
+		return ret;
+	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+	return brightness & 0xff;
+}
+static const struct backlight_ops hx8389c_gh9607501a_bl_ops = {
+	.update_status = hx8389c_gh9607501a_bl_update_status,
+	.get_brightness = hx8389c_gh9607501a_bl_get_brightness,
+};
+static struct backlight_device *
+hx8389c_gh9607501a_create_backlight(struct mipi_dsi_device *dsi)
+{
+	struct device *dev = &dsi->dev;
+	const struct backlight_properties props = {
+		.type = BACKLIGHT_RAW,
+		.brightness = 255,
+		.max_brightness = 255,
+	};
+	return devm_backlight_device_register(dev, dev_name(dev), dev, dsi,
+					      &hx8389c_gh9607501a_bl_ops, &props);
+}
+
 static int hx8389c_gh9607501a_probe(struct mipi_dsi_device *dsi)
 {
 	struct device *dev = &dsi->dev;
@@ -281,9 +325,11 @@ static int hx8389c_gh9607501a_probe(struct mipi_dsi_device *dsi)
 	drm_panel_init(&ctx->panel, dev, &hx8389c_gh9607501a_panel_funcs,
 		       DRM_MODE_CONNECTOR_DSI);
 
-	ret = drm_panel_of_backlight(&ctx->panel);
-	if (ret)
-		return dev_err_probe(dev, ret, "Failed to get backlight\n");
+	ctx->panel.backlight = hx8389c_gh9607501a_create_backlight(dsi);
+	if (IS_ERR(ctx->panel.backlight))
+		return dev_err_probe(dev, PTR_ERR(ctx->panel.backlight),
+				     "Failed to create backlight\n");
+
 
 	drm_panel_add(&ctx->panel);
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-hx8389c.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-hx8389c.c
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2022 FIXME
+// Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
+//   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
+
+#include <linux/backlight.h>
+#include <linux/delay.h>
+#include <linux/gpio/consumer.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/regulator/consumer.h>
+
+#include <video/mipi_display.h>
+
+#include <drm/drm_mipi_dsi.h>
+#include <drm/drm_modes.h>
+#include <drm/drm_panel.h>
+
+struct hx8389c {
+	struct drm_panel panel;
+	struct mipi_dsi_device *dsi;
+	struct regulator_bulk_data supplies[2];
+	struct gpio_desc *reset_gpio;
+	bool prepared;
+};
+
+static inline struct hx8389c *to_hx8389c(struct drm_panel *panel)
+{
+	return container_of(panel, struct hx8389c, panel);
+}
+
+#define dsi_dcs_write_seq(dsi, seq...) do {				\
+		static const u8 d[] = { seq };				\
+		int ret;						\
+		ret = mipi_dsi_dcs_write_buffer(dsi, d, ARRAY_SIZE(d));	\
+		if (ret < 0)						\
+			return ret;					\
+	} while (0)
+
+static void hx8389c_reset(struct hx8389c *ctx)
+{
+	gpiod_set_value_cansleep(ctx->reset_gpio, 0);
+	usleep_range(10000, 11000);
+	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+	usleep_range(2000, 3000);
+	gpiod_set_value_cansleep(ctx->reset_gpio, 0);
+	msleep(80);
+}
+
+static int hx8389c_on(struct hx8389c *ctx)
+{
+	struct mipi_dsi_device *dsi = ctx->dsi;
+	struct device *dev = &dsi->dev;
+	int ret;
+
+	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+
+	dsi_dcs_write_seq(dsi, 0xb9, 0xff, 0x83, 0x89);
+	usleep_range(10000, 11000);
+	dsi_dcs_write_seq(dsi, 0xb1,
+			  0x7f, 0x10, 0x10, 0xd2, 0x32, 0x80, 0x10, 0xf0, 0x56,
+			  0x80, 0x20, 0x20, 0xf8, 0xaa, 0xaa, 0xa1, 0x00, 0x80,
+			  0x30, 0x00);
+	dsi_dcs_write_seq(dsi, 0xb2,
+			  0x82, 0x50, 0x05, 0x07, 0xf0, 0x38, 0x11, 0x64, 0x5d,
+			  0x09);
+	dsi_dcs_write_seq(dsi, 0xb4,
+			  0x66, 0x66, 0x66, 0x70, 0x00, 0x00, 0x18, 0x76, 0x28,
+			  0x76, 0xa8);
+	dsi_dcs_write_seq(dsi, 0xd2, 0x33);
+	dsi_dcs_write_seq(dsi, 0xc0, 0x30, 0x17, 0x00, 0x03);
+	dsi_dcs_write_seq(dsi, 0xc7, 0x00, 0x80, 0x00, 0xc0);
+	dsi_dcs_write_seq(dsi, 0xbf, 0x05, 0x50, 0x00, 0x3e);
+	usleep_range(10000, 11000);
+	dsi_dcs_write_seq(dsi, 0xb9, 0xff, 0x83, 0x89);
+	dsi_dcs_write_seq(dsi, 0xcc, 0x0e);
+	dsi_dcs_write_seq(dsi, 0xd3,
+			  0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x00, 0x32, 0x10,
+			  0x00, 0x00, 0x00, 0x03, 0xc6, 0x03, 0xc6, 0x00, 0x00,
+			  0x00, 0x00, 0x35, 0x33, 0x04, 0x04, 0x37, 0x00, 0x00,
+			  0x00, 0x05, 0x08, 0x00, 0x00, 0x0a, 0x00, 0x01);
+	dsi_dcs_write_seq(dsi, 0xd5,
+			  0x18, 0x18, 0x18, 0x18, 0x19, 0x19, 0x18, 0x18, 0x20,
+			  0x21, 0x24, 0x25, 0x18, 0x18, 0x18, 0x18, 0x00, 0x01,
+			  0x04, 0x05, 0x02, 0x03, 0x06, 0x07, 0x18, 0x18, 0x18,
+			  0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18,
+			  0x18, 0x18);
+	dsi_dcs_write_seq(dsi, 0xd6,
+			  0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x19, 0x19, 0x25,
+			  0x24, 0x21, 0x20, 0x18, 0x18, 0x18, 0x18, 0x07, 0x06,
+			  0x03, 0x02, 0x05, 0x04, 0x01, 0x00, 0x18, 0x18, 0x18,
+			  0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18, 0x18,
+			  0x18, 0x18);
+	dsi_dcs_write_seq(dsi, 0xb7, 0x20, 0x80, 0x00);
+	dsi_dcs_write_seq(dsi, 0xe0,
+			  0x00, 0x02, 0x06, 0x38, 0x3c, 0x3f, 0x1b, 0x46, 0x06,
+			  0x09, 0x0c, 0x17, 0x10, 0x13, 0x16, 0x13, 0x14, 0x08,
+			  0x13, 0x15, 0x19, 0x00, 0x02, 0x06, 0x37, 0x3c, 0x3f,
+			  0x1a, 0x45, 0x05, 0x09, 0x0b, 0x16, 0x0f, 0x13, 0x15,
+			  0x13, 0x14, 0x07, 0x12, 0x14, 0x18);
+	dsi_dcs_write_seq(dsi, 0xbd, 0x00);
+	dsi_dcs_write_seq(dsi, 0xc1,
+			  0x00, 0x00, 0x08, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38,
+			  0x40, 0x48, 0x50, 0x58, 0x60, 0x68, 0x70, 0x78, 0x80,
+			  0x88, 0x90, 0x98, 0xa0, 0xa8, 0xb0, 0xb8, 0xc0, 0xc8,
+			  0xd0, 0xd8, 0xe0, 0xe8, 0xf0, 0xf8, 0xff, 0x00, 0x00,
+			  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_dcs_write_seq(dsi, 0xbd, 0x01);
+	dsi_dcs_write_seq(dsi, 0xc1,
+			  0x00, 0x08, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38, 0x40,
+			  0x48, 0x50, 0x58, 0x60, 0x68, 0x70, 0x78, 0x80, 0x88,
+			  0x90, 0x98, 0xa0, 0xa8, 0xb0, 0xb8, 0xc0, 0xc8, 0xd0,
+			  0xd8, 0xe0, 0xe8, 0xf0, 0xf8, 0xff, 0x00, 0x00, 0x00,
+			  0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_dcs_write_seq(dsi, 0xbd, 0x02);
+	dsi_dcs_write_seq(dsi, 0xc1,
+			  0x00, 0x08, 0x10, 0x18, 0x20, 0x28, 0x30, 0x38, 0x40,
+			  0x48, 0x50, 0x58, 0x60, 0x68, 0x70, 0x78, 0x80, 0x88,
+			  0x90, 0x98, 0xa0, 0xa8, 0xb0, 0xb8, 0xc0, 0xc8, 0xd0,
+			  0xd8, 0xe0, 0xe8, 0xf0, 0xf8, 0xff, 0x00, 0x00, 0x00,
+			  0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_dcs_write_seq(dsi, 0xc9,
+			  0x1f, 0x00, 0x0f, 0x1e, 0x81, 0x1e, 0x00, 0x00, 0x01,
+			  0x19, 0x00, 0x00, 0x20);
+	usleep_range(5000, 6000);
+	dsi_dcs_write_seq(dsi, MIPI_DCS_WRITE_POWER_SAVE, 0x00);
+	usleep_range(5000, 6000);
+	dsi_dcs_write_seq(dsi, MIPI_DCS_WRITE_CONTROL_DISPLAY, 0x24);
+	usleep_range(5000, 6000);
+
+	ret = mipi_dsi_dcs_exit_sleep_mode(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to exit sleep mode: %d\n", ret);
+		return ret;
+	}
+	msleep(125);
+
+	ret = mipi_dsi_dcs_set_display_on(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to set display on: %d\n", ret);
+		return ret;
+	}
+	usleep_range(5000, 6000);
+
+	return 0;
+}
+
+static int hx8389c_off(struct hx8389c *ctx)
+{
+	struct mipi_dsi_device *dsi = ctx->dsi;
+
+	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
+
+	dsi_dcs_write_seq(dsi, 0x28, 0x00);
+	msleep(60);
+	dsi_dcs_write_seq(dsi, 0x10, 0x00);
+	msleep(60);
+
+	return 0;
+}
+
+static int hx8389c_prepare(struct drm_panel *panel)
+{
+	struct hx8389c *ctx = to_hx8389c(panel);
+	struct device *dev = &ctx->dsi->dev;
+	int ret;
+
+	if (ctx->prepared)
+		return 0;
+
+	ret = regulator_bulk_enable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+	if (ret < 0) {
+		dev_err(dev, "Failed to enable regulators: %d\n", ret);
+		return ret;
+	}
+
+	hx8389c_reset(ctx);
+
+	ret = hx8389c_on(ctx);
+	if (ret < 0) {
+		dev_err(dev, "Failed to initialize panel: %d\n", ret);
+		gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+		regulator_bulk_disable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+		return ret;
+	}
+
+	ctx->prepared = true;
+	return 0;
+}
+
+static int hx8389c_unprepare(struct drm_panel *panel)
+{
+	struct hx8389c *ctx = to_hx8389c(panel);
+	struct device *dev = &ctx->dsi->dev;
+	int ret;
+
+	if (!ctx->prepared)
+		return 0;
+
+	ret = hx8389c_off(ctx);
+	if (ret < 0)
+		dev_err(dev, "Failed to un-initialize panel: %d\n", ret);
+
+	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+	regulator_bulk_disable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+
+	ctx->prepared = false;
+	return 0;
+}
+
+static const struct drm_display_mode hx8389c_mode = {
+	.clock = (540 + 10 + 14 + 10) * (960 + 9 + 2 + 5) * 60 / 1000,
+	.hdisplay = 540,
+	.hsync_start = 540 + 10,
+	.hsync_end = 540 + 10 + 14,
+	.htotal = 540 + 10 + 14 + 10,
+	.vdisplay = 960,
+	.vsync_start = 960 + 9,
+	.vsync_end = 960 + 9 + 2,
+	.vtotal = 960 + 9 + 2 + 5,
+	.width_mm = 62,
+	.height_mm = 110,
+};
+
+static int hx8389c_get_modes(struct drm_panel *panel,
+			     struct drm_connector *connector)
+{
+	struct drm_display_mode *mode;
+
+	mode = drm_mode_duplicate(connector->dev, &hx8389c_mode);
+	if (!mode)
+		return -ENOMEM;
+
+	drm_mode_set_name(mode);
+
+	mode->type = DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED;
+	connector->display_info.width_mm = mode->width_mm;
+	connector->display_info.height_mm = mode->height_mm;
+	drm_mode_probed_add(connector, mode);
+
+	return 1;
+}
+
+static const struct drm_panel_funcs hx8389c_panel_funcs = {
+	.prepare = hx8389c_prepare,
+	.unprepare = hx8389c_unprepare,
+	.get_modes = hx8389c_get_modes,
+};
+
+static int hx8389c_bl_update_status(struct backlight_device *bl)
+{
+	struct mipi_dsi_device *dsi = bl_get_data(bl);
+	u16 brightness = backlight_get_brightness(bl);
+	int ret;
+
+	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
+
+	ret = mipi_dsi_dcs_set_display_brightness(dsi, brightness);
+	if (ret < 0)
+		return ret;
+
+	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+
+	return 0;
+}
+
+// TODO: Check if /sys/class/backlight/.../actual_brightness actually returns
+// correct values. If not, remove this function.
+static int hx8389c_bl_get_brightness(struct backlight_device *bl)
+{
+	struct mipi_dsi_device *dsi = bl_get_data(bl);
+	u16 brightness;
+	int ret;
+
+	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
+
+	ret = mipi_dsi_dcs_get_display_brightness(dsi, &brightness);
+	if (ret < 0)
+		return ret;
+
+	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+
+	return brightness & 0xff;
+}
+
+static const struct backlight_ops hx8389c_bl_ops = {
+	.update_status = hx8389c_bl_update_status,
+	.get_brightness = hx8389c_bl_get_brightness,
+};
+
+static struct backlight_device *
+hx8389c_create_backlight(struct mipi_dsi_device *dsi)
+{
+	struct device *dev = &dsi->dev;
+	const struct backlight_properties props = {
+		.type = BACKLIGHT_RAW,
+		.brightness = 255,
+		.max_brightness = 255,
+	};
+
+	return devm_backlight_device_register(dev, dev_name(dev), dev, dsi,
+					      &hx8389c_bl_ops, &props);
+}
+
+static int hx8389c_probe(struct mipi_dsi_device *dsi)
+{
+	struct device *dev = &dsi->dev;
+	struct hx8389c *ctx;
+	int ret;
+
+	ctx = devm_kzalloc(dev, sizeof(*ctx), GFP_KERNEL);
+	if (!ctx)
+		return -ENOMEM;
+
+	ctx->supplies[0].supply = "vreg";
+	ctx->supplies[1].supply = "vdd";
+	ret = devm_regulator_bulk_get(dev, ARRAY_SIZE(ctx->supplies),
+				      ctx->supplies);
+	if (ret < 0)
+		return dev_err_probe(dev, ret, "Failed to get regulators\n");
+
+	ctx->reset_gpio = devm_gpiod_get(dev, "reset", GPIOD_OUT_HIGH);
+	if (IS_ERR(ctx->reset_gpio))
+		return dev_err_probe(dev, PTR_ERR(ctx->reset_gpio),
+				     "Failed to get reset-gpios\n");
+
+	ctx->dsi = dsi;
+	mipi_dsi_set_drvdata(dsi, ctx);
+
+	dsi->lanes = 2;
+	dsi->format = MIPI_DSI_FMT_RGB888;
+	dsi->mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_SYNC_PULSE |
+			  MIPI_DSI_MODE_NO_EOT_PACKET |
+			  MIPI_DSI_CLOCK_NON_CONTINUOUS;
+
+	drm_panel_init(&ctx->panel, dev, &hx8389c_panel_funcs,
+		       DRM_MODE_CONNECTOR_DSI);
+
+	ctx->panel.backlight = hx8389c_create_backlight(dsi);
+	if (IS_ERR(ctx->panel.backlight))
+		return dev_err_probe(dev, PTR_ERR(ctx->panel.backlight),
+				     "Failed to create backlight\n");
+
+	drm_panel_add(&ctx->panel);
+
+	ret = mipi_dsi_attach(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to attach to DSI host: %d\n", ret);
+		drm_panel_remove(&ctx->panel);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int hx8389c_remove(struct mipi_dsi_device *dsi)
+{
+	struct hx8389c *ctx = mipi_dsi_get_drvdata(dsi);
+	int ret;
+
+	ret = mipi_dsi_detach(dsi);
+	if (ret < 0)
+		dev_err(&dsi->dev, "Failed to detach from DSI host: %d\n", ret);
+
+	drm_panel_remove(&ctx->panel);
+
+	return 0;
+}
+
+static const struct of_device_id hx8389c_of_match[] = {
+	{ .compatible = "samsung,hx8389c" }, // FIXME
+	{ /* sentinel */ }
+};
+MODULE_DEVICE_TABLE(of, hx8389c_of_match);
+
+static struct mipi_dsi_driver hx8389c_driver = {
+	.probe = hx8389c_probe,
+	.remove = hx8389c_remove,
+	.driver = {
+		.name = "panel-hx8389c",
+		.of_match_table = hx8389c_of_match,
+	},
+};
+module_mipi_dsi_driver(hx8389c_driver);
+
+MODULE_AUTHOR("linux-mdss-dsi-panel-driver-generator <fix@me>"); // FIXME
+MODULE_DESCRIPTION("DRM driver for HX8389C qhd video mode dsi panel");
+MODULE_LICENSE("GPL v2");

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-s6d78a0-gh9607501a.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-s6d78a0-gh9607501a.c
@@ -1,0 +1,301 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2022 FIXME
+// Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
+//   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
+
+#include <linux/delay.h>
+#include <linux/gpio/consumer.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/regulator/consumer.h>
+
+#include <video/mipi_display.h>
+
+#include <drm/drm_mipi_dsi.h>
+#include <drm/drm_modes.h>
+#include <drm/drm_panel.h>
+
+struct s6d78a0_gh9607501a {
+	struct drm_panel panel;
+	struct mipi_dsi_device *dsi;
+	struct regulator_bulk_data supplies[2];
+	struct gpio_desc *reset_gpio;
+	bool prepared;
+};
+
+static inline
+struct s6d78a0_gh9607501a *to_s6d78a0_gh9607501a(struct drm_panel *panel)
+{
+	return container_of(panel, struct s6d78a0_gh9607501a, panel);
+}
+
+#define dsi_dcs_write_seq(dsi, seq...) do {				\
+		static const u8 d[] = { seq };				\
+		int ret;						\
+		ret = mipi_dsi_dcs_write_buffer(dsi, d, ARRAY_SIZE(d));	\
+		if (ret < 0)						\
+			return ret;					\
+	} while (0)
+
+static void s6d78a0_gh9607501a_reset(struct s6d78a0_gh9607501a *ctx)
+{
+	gpiod_set_value_cansleep(ctx->reset_gpio, 0);
+	usleep_range(10000, 11000);
+	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+	usleep_range(5000, 6000);
+	gpiod_set_value_cansleep(ctx->reset_gpio, 0);
+	msleep(30);
+}
+
+static int s6d78a0_gh9607501a_on(struct s6d78a0_gh9607501a *ctx)
+{
+	struct mipi_dsi_device *dsi = ctx->dsi;
+	struct device *dev = &dsi->dev;
+	int ret;
+
+	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+
+	dsi_dcs_write_seq(dsi, 0xf0, 0x5a, 0x5a);
+	dsi_dcs_write_seq(dsi, 0xf1, 0x5a, 0x5a);
+	dsi_dcs_write_seq(dsi, 0xfc, 0xa5, 0xa5);
+
+	ret = mipi_dsi_dcs_exit_sleep_mode(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to exit sleep mode: %d\n", ret);
+		return ret;
+	}
+	msleep(120);
+
+	dsi_dcs_write_seq(dsi, 0xb1, 0x93);
+	dsi_dcs_write_seq(dsi, 0xb5, 0x10);
+	dsi_dcs_write_seq(dsi, 0xf4,
+			  0x01, 0x10, 0x32, 0x00, 0x24, 0x26, 0x28, 0x27, 0x27,
+			  0x27, 0xb7, 0x2b, 0x2c, 0x65, 0x6a, 0x34, 0x20);
+	dsi_dcs_write_seq(dsi, 0xef,
+			  0x01, 0x01, 0x81, 0x22, 0x83, 0x04, 0x00, 0x00, 0x00,
+			  0x00, 0x28, 0x81, 0x00, 0x21, 0x21, 0x03, 0x03, 0x40,
+			  0x00, 0x10);
+	dsi_dcs_write_seq(dsi, 0xf2,
+			  0x19, 0x04, 0x08, 0x08, 0x08, 0x14, 0x14, 0x00);
+	dsi_dcs_write_seq(dsi, 0xf6, 0x93, 0x23, 0x15, 0x07, 0x07, 0x0c);
+	dsi_dcs_write_seq(dsi, 0xe1, 0x01, 0xff, 0x01, 0x1b, 0x20, 0x17);
+	dsi_dcs_write_seq(dsi, 0xe2, 0xed, 0xc7, 0x23);
+	dsi_dcs_write_seq(dsi, 0xf7,
+			  0x01, 0x01, 0x0a, 0x0b, 0x05, 0x1b, 0x1a, 0x01, 0x01,
+			  0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+			  0x01, 0x01, 0x01, 0x08, 0x09, 0x04, 0x1b, 0x1a, 0x01,
+			  0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01,
+			  0x01, 0x01);
+	dsi_dcs_write_seq(dsi, MIPI_DCS_SET_ADDRESS_MODE, 0x10);
+	dsi_dcs_write_seq(dsi, 0xfa,
+			  0x00, 0x19, 0x21, 0x1e, 0x14, 0x0b, 0x10, 0x0e, 0x09,
+			  0x0b, 0x00, 0x00, 0x0a, 0x00, 0x1d, 0x21, 0x1e, 0x14,
+			  0x0b, 0x10, 0x0e, 0x09, 0x0b, 0x00, 0x00, 0x0a, 0x00,
+			  0x1c, 0x21, 0x1e, 0x14, 0x0b, 0x10, 0x0e, 0x09, 0x0b,
+			  0x00, 0x00, 0x0a);
+	dsi_dcs_write_seq(dsi, 0xfb,
+			  0x07, 0x2d, 0x22, 0x24, 0x18, 0x0e, 0x11, 0x0c, 0x05,
+			  0x05, 0x00, 0x00, 0x0a, 0x00, 0x29, 0x22, 0x24, 0x18,
+			  0x0e, 0x11, 0x0c, 0x05, 0x05, 0x00, 0x00, 0x0a, 0x07,
+			  0x2a, 0x22, 0x24, 0x18, 0x0e, 0x11, 0x0c, 0x05, 0x05,
+			  0x00, 0x00, 0x0a);
+
+	ret = mipi_dsi_dcs_set_display_on(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to set display on: %d\n", ret);
+		return ret;
+	}
+	msleep(20);
+
+	dsi_dcs_write_seq(dsi, 0xf0, 0xa5, 0xa5);
+	dsi_dcs_write_seq(dsi, 0xf1, 0xa5, 0xa5);
+	dsi_dcs_write_seq(dsi, 0xfc, 0x5a, 0x5a);
+
+	return 0;
+}
+
+static int s6d78a0_gh9607501a_off(struct s6d78a0_gh9607501a *ctx)
+{
+	struct mipi_dsi_device *dsi = ctx->dsi;
+
+	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
+
+	dsi_dcs_write_seq(dsi, 0x28, 0x00);
+	msleep(40);
+	dsi_dcs_write_seq(dsi, 0x10, 0x00);
+	msleep(100);
+
+	return 0;
+}
+
+static int s6d78a0_gh9607501a_prepare(struct drm_panel *panel)
+{
+	struct s6d78a0_gh9607501a *ctx = to_s6d78a0_gh9607501a(panel);
+	struct device *dev = &ctx->dsi->dev;
+	int ret;
+
+	if (ctx->prepared)
+		return 0;
+
+	ret = regulator_bulk_enable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+	if (ret < 0) {
+		dev_err(dev, "Failed to enable regulators: %d\n", ret);
+		return ret;
+	}
+
+	s6d78a0_gh9607501a_reset(ctx);
+
+	ret = s6d78a0_gh9607501a_on(ctx);
+	if (ret < 0) {
+		dev_err(dev, "Failed to initialize panel: %d\n", ret);
+		gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+		regulator_bulk_disable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+		return ret;
+	}
+
+	ctx->prepared = true;
+	return 0;
+}
+
+static int s6d78a0_gh9607501a_unprepare(struct drm_panel *panel)
+{
+	struct s6d78a0_gh9607501a *ctx = to_s6d78a0_gh9607501a(panel);
+	struct device *dev = &ctx->dsi->dev;
+	int ret;
+
+	if (!ctx->prepared)
+		return 0;
+
+	ret = s6d78a0_gh9607501a_off(ctx);
+	if (ret < 0)
+		dev_err(dev, "Failed to un-initialize panel: %d\n", ret);
+
+	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+	regulator_bulk_disable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+
+	ctx->prepared = false;
+	return 0;
+}
+
+static const struct drm_display_mode s6d78a0_gh9607501a_mode = {
+	.clock = (540 + 10 + 14 + 10) * (960 + 8 + 2 + 6) * 60 / 1000,
+	.hdisplay = 540,
+	.hsync_start = 540 + 10,
+	.hsync_end = 540 + 10 + 14,
+	.htotal = 540 + 10 + 14 + 10,
+	.vdisplay = 960,
+	.vsync_start = 960 + 8,
+	.vsync_end = 960 + 8 + 2,
+	.vtotal = 960 + 8 + 2 + 6,
+	.width_mm = 62,
+	.height_mm = 110,
+};
+
+static int s6d78a0_gh9607501a_get_modes(struct drm_panel *panel,
+					struct drm_connector *connector)
+{
+	struct drm_display_mode *mode;
+
+	mode = drm_mode_duplicate(connector->dev, &s6d78a0_gh9607501a_mode);
+	if (!mode)
+		return -ENOMEM;
+
+	drm_mode_set_name(mode);
+
+	mode->type = DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED;
+	connector->display_info.width_mm = mode->width_mm;
+	connector->display_info.height_mm = mode->height_mm;
+	drm_mode_probed_add(connector, mode);
+
+	return 1;
+}
+
+static const struct drm_panel_funcs s6d78a0_gh9607501a_panel_funcs = {
+	.prepare = s6d78a0_gh9607501a_prepare,
+	.unprepare = s6d78a0_gh9607501a_unprepare,
+	.get_modes = s6d78a0_gh9607501a_get_modes,
+};
+
+static int s6d78a0_gh9607501a_probe(struct mipi_dsi_device *dsi)
+{
+	struct device *dev = &dsi->dev;
+	struct s6d78a0_gh9607501a *ctx;
+	int ret;
+
+	ctx = devm_kzalloc(dev, sizeof(*ctx), GFP_KERNEL);
+	if (!ctx)
+		return -ENOMEM;
+
+	ctx->supplies[0].supply = "vreg";
+	ctx->supplies[1].supply = "vdd";
+	ret = devm_regulator_bulk_get(dev, ARRAY_SIZE(ctx->supplies),
+				      ctx->supplies);
+	if (ret < 0)
+		return dev_err_probe(dev, ret, "Failed to get regulators\n");
+
+	ctx->reset_gpio = devm_gpiod_get(dev, "reset", GPIOD_OUT_HIGH);
+	if (IS_ERR(ctx->reset_gpio))
+		return dev_err_probe(dev, PTR_ERR(ctx->reset_gpio),
+				     "Failed to get reset-gpios\n");
+
+	ctx->dsi = dsi;
+	mipi_dsi_set_drvdata(dsi, ctx);
+
+	dsi->lanes = 2;
+	dsi->format = MIPI_DSI_FMT_RGB888;
+	dsi->mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_SYNC_PULSE |
+			  MIPI_DSI_MODE_NO_EOT_PACKET |
+			  MIPI_DSI_CLOCK_NON_CONTINUOUS;
+
+	drm_panel_init(&ctx->panel, dev, &s6d78a0_gh9607501a_panel_funcs,
+		       DRM_MODE_CONNECTOR_DSI);
+
+	ret = drm_panel_of_backlight(&ctx->panel);
+	if (ret)
+		return dev_err_probe(dev, ret, "Failed to get backlight\n");
+
+	drm_panel_add(&ctx->panel);
+
+	ret = mipi_dsi_attach(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to attach to DSI host: %d\n", ret);
+		drm_panel_remove(&ctx->panel);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int s6d78a0_gh9607501a_remove(struct mipi_dsi_device *dsi)
+{
+	struct s6d78a0_gh9607501a *ctx = mipi_dsi_get_drvdata(dsi);
+	int ret;
+
+	ret = mipi_dsi_detach(dsi);
+	if (ret < 0)
+		dev_err(&dsi->dev, "Failed to detach from DSI host: %d\n", ret);
+
+	drm_panel_remove(&ctx->panel);
+
+	return 0;
+}
+
+static const struct of_device_id s6d78a0_gh9607501a_of_match[] = {
+	{ .compatible = "samsung,s6d78a0-gh9607501a" }, // FIXME
+	{ /* sentinel */ }
+};
+MODULE_DEVICE_TABLE(of, s6d78a0_gh9607501a_of_match);
+
+static struct mipi_dsi_driver s6d78a0_gh9607501a_driver = {
+	.probe = s6d78a0_gh9607501a_probe,
+	.remove = s6d78a0_gh9607501a_remove,
+	.driver = {
+		.name = "panel-s6d78a0-gh9607501a",
+		.of_match_table = s6d78a0_gh9607501a_of_match,
+	},
+};
+module_mipi_dsi_driver(s6d78a0_gh9607501a_driver);
+
+MODULE_AUTHOR("linux-mdss-dsi-panel-driver-generator <fix@me>"); // FIXME
+MODULE_DESCRIPTION("DRM driver for S6D78A0 qhd video mode dsi panel");
+MODULE_LICENSE("GPL v2");

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-s6d7aa0-lsl080al03.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-s6d7aa0-lsl080al03.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-s6d7aa0-ltl101at01.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-s6d7aa0-ltl101at01.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-wingtech-auo-nt35521.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-wingtech-auo-nt35521.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-wingtech-auo-r61308.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-wingtech-auo-r61308.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-wingtech-boe-nt35521s.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-wingtech-boe-nt35521s.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-wingtech-ebbg-otm1285a.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-wingtech-ebbg-otm1285a.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-wingtech-sharp-r69431.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-wingtech-sharp-r69431.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-wingtech-tianma-hx8394d.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-wingtech-tianma-hx8394d.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-wingtech-yassy-ili9881.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-wingtech-yassy-ili9881.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-// Copyright (c) 2021 FIXME
+// Copyright (c) 2022 FIXME
 // Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
 //   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
 

--- a/drivers/thermal/qcom/tsens.c
+++ b/drivers/thermal/qcom/tsens.c
@@ -825,9 +825,12 @@ int __init init_common(struct tsens_priv *priv)
 	if (tsens_version(priv) == VER_0)
 		regmap_field_write(priv->rf[TSENS_EN], 1);
 
+	/*HACK For gprime
 	ret = regmap_field_read(priv->rf[TSENS_EN], &enabled);
 	if (ret)
 		goto err_put_device;
+	*/
+	enabled = true;
 	if (!enabled) {
 		dev_err(dev, "%s: device not enabled\n", __func__);
 		ret = -ENODEV;


### PR DESCRIPTION
Samsung Galaxy Grand Prime (SM-G530Y) is a smartphone using the MSM8916
SoC released in 2014.

The Grand Prime variants are very similar, with some differences in
accelerometer and NFC. The common parts are shared in
msm8916-samsung-gprime.dts to reduce duplication.

Todo:
- [ ] #219 
- [ ] Drop f0557ff 
- [x] msm8916-mainline/lk2nd#143
- [x] msm8916-mainline/linux-panel-drivers#11