### PR TITLE
Fix wcnss IRQs

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916.dtsi
@@ -1874,8 +1874,8 @@
 					<&rpmpd MSM8916_VDDMX>;
 			power-domain-names = "cx", "mx";
 
-			qcom,state = <&wcnss_smp2p_out 0>;
-			qcom,state-names = "stop";
+			qcom,smem-states = <&wcnss_smp2p_out 0>;
+			qcom,smem-state-names = "stop";
 
 			pinctrl-names = "default";
 			pinctrl-0 = <&wcnss_pin_a>;

--- a/drivers/remoteproc/qcom_wcnss.c
+++ b/drivers/remoteproc/qcom_wcnss.c
@@ -481,10 +481,13 @@ static int wcnss_request_irq(struct qcom_wcnss *wcnss,
 					NULL, thread_fn,
 					IRQF_TRIGGER_RISING | IRQF_ONESHOT,
 					"wcnss", wcnss);
-	if (ret)
+	if (ret) {
 		dev_err(&pdev->dev, "request %s IRQ failed\n", name);
+		return ret;
+	}
 
-	return ret;
+	/* Return > 0 if the IRQ was successfully aquired */
+	return 1;
 }
 
 static int wcnss_alloc_memory_region(struct qcom_wcnss *wcnss)


### PR DESCRIPTION
The wcnss-pil loader driver has a bug in the handling of the stop-ack IRQ. This  bug prevents the IRQ from being used when WCNSS is shutdown, even if it is available and properly described in the device tree. The first commit fixes the handling of the IRQ. The second commit fixes a typo in the device-tree for msm8916's `wcnss` node, which prevents it from being probed successfully when the first commit is applied.