### PR TITLE
arm64: dts: qcom: msm8916-samsung-{cprime,heatqlte}: Add initial device tree

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -1001,6 +1001,7 @@ dtb-$(CONFIG_ARCH_QCOM) += \
 	qcom-msm8916-samsung-e7.dtb \
 	qcom-msm8916-samsung-fortunaltezt.dtb \
 	qcom-msm8916-samsung-grandmax.dtb \
+	qcom-msm8916-samsung-heatqlte.dtb \
 	qcom-msm8916-samsung-serranove.dtb \
 	qcom-msm8960-cdp.dtb \
 	qcom-msm8974-fairphone-fp2.dtb \

--- a/arch/arm/boot/dts/qcom-msm8916-samsung-heatqlte.dts
+++ b/arch/arm/boot/dts/qcom-msm8916-samsung-heatqlte.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include "arm64/qcom/msm8916-samsung-heatqlte.dts"
+#include "qcom-msm8916-smp.dtsi"
+
+&tsens {
+	/* The device crashes when accessing the SROT region for some reason */
+	qcom,srot-locked;
+};

--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -27,6 +27,7 @@ dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-mtp.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-a3u-eur.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-a5-zt.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-a5u-eur.dtb
+dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-cprime.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-e7.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-fortuna3g.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-fortunaltezt.dtb

--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -35,6 +35,7 @@ dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-gprimeltecan.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-grandmax.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-gt510.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-gt58.dtb
+dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-heatqlte.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-j3ltetw.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-j5.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-j5x.dtb

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-cprime-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-cprime-common.dtsi
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include "msm8916-samsung-gprime-common.dtsi"
+
+/ {
+	reserved-memory {
+		/* Additional memory used by Samsung firmware modifications */
+		tz-apps@85a00000 {
+			reg = <0x0 0x85a00000 0x0 0x600000>;
+			no-map;
+		};
+	};
+};
+
+&blsp_i2c1 {
+	/* SM5504 MUIC instead of SM5502 */
+	/delete-node/ extcon@25;
+
+	muic: extcon@14 {
+		compatible = "siliconmitus,sm5504-muic";
+		reg = <0x14>;
+		interrupt-parent = <&msmgpio>;
+		interrupts = <12 IRQ_TYPE_EDGE_FALLING>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&muic_int_default>;
+	};
+};
+
+&blsp_i2c5 {
+	status = "disabled";
+	/delete-node/ touchscreen@20;
+};
+
+/* On cprime backlight is controlled with MIPI DCS commands */
+&clk_pwm {
+	status = "disabled";
+};
+
+&clk_pwm_backlight {
+	status = "disabled";
+};
+
+&i2c_nfc {
+	status = "okay";
+};
+
+&panel {
+	/delete-property/ backlight;
+};
+
+&s3fwrn5_nfc {
+	status = "okay";
+};
+
+&st_accel {
+	status = "okay";
+	compatible = "st,lis2hh12";
+	mount-matrix = "1",  "0", "0",
+		       "0", "-1", "0",
+		       "0",  "0", "1";
+};

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-cprime.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-cprime.dts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include "msm8916-samsung-cprime-common.dtsi"
+
+/ {
+	model = "Samsung Galaxy Core Prime";
+	compatible = "samsung,cprime", "qcom,msm8916";
+	chassis-type = "handset";
+
+	reserved-memory {
+		mpss_mem: mpss@86800000 {
+			reg = <0x0 0x86800000 0x0 0x5800000>;
+			no-map;
+		};
+
+		gps_mem: gps@8c000000 {
+			reg = <0x0 0x8c000000 0x0 0x200000>;
+			no-map;
+		};
+	};
+};

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-cprime.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-cprime.dts
@@ -21,3 +21,7 @@
 		};
 	};
 };
+
+&panel {
+	compatible = "samsung,cprime-panel";
+};

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
@@ -51,20 +51,10 @@
 
 &i2c_nfc {
 	status = "okay";
+};
 
-	nfc@2b {
-		compatible = "nxp,pn547", "nxp,nxp-nci-i2c";
-		reg = <0x2b>;
-
-		interrupt-parent = <&msmgpio>;
-		interrupts = <21 IRQ_TYPE_EDGE_RISING>;
-
-		enable-gpios = <&msmgpio 20 GPIO_ACTIVE_HIGH>;
-		firmware-gpios = <&msmgpio 49 GPIO_ACTIVE_HIGH>;
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&nfc_default>;
-	};
+&pn547_nfc {
+	status = "okay";
 };
 
 &panel {

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
@@ -109,6 +109,22 @@
 
 		/* Used for NFC on some variants */
 		status = "disabled";
+
+		pn547_nfc: nfc@2b {
+			compatible = "nxp,pn547", "nxp,nxp-nci-i2c";
+			reg = <0x2b>;
+
+			interrupt-parent = <&msmgpio>;
+			interrupts = <21 IRQ_TYPE_EDGE_RISING>;
+
+			enable-gpios = <&msmgpio 20 GPIO_ACTIVE_HIGH>;
+			firmware-gpios = <&msmgpio 49 GPIO_ACTIVE_HIGH>;
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&nfc_default>;
+
+			status = "disabled";
+		};
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
@@ -125,6 +125,24 @@
 
 			status = "disabled";
 		};
+
+		s3fwrn5_nfc: nfc@27 {
+			compatible = "samsung,s3fwrn5-i2c";
+			reg = <0x27>;
+
+			interrupt-parent = <&msmgpio>;
+			interrupts = <21 IRQ_TYPE_EDGE_RISING>;
+
+			en-gpios = <&msmgpio 20 GPIO_ACTIVE_HIGH>;
+			wake-gpios = <&msmgpio 49 GPIO_ACTIVE_HIGH>;
+
+			clocks = <&rpmcc RPM_SMD_BB_CLK2_PIN>;
+
+			pinctrl-names = "default";
+			pinctrl-0 = <&nfc_default>, <&nfc_clk_req>;
+
+			status = "disabled";
+		};
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-heatqlte.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-heatqlte.dts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include "msm8916-samsung-cprime-common.dtsi"
+
+/*
+ * NOTE: The original firmware from Samsung can only boot ARM32 kernels.
+ * Unfortunately, the firmware is signed and cannot be replaced easily.
+ * There seems to be no way to boot ARM64 kernels on this device at the moment,
+ * even though the hardware would support it.
+ *
+ * However, it is possible to use this device tree by compiling an ARM32 kernel
+ * instead. For clarity and build testing this device tree is maintained next
+ * to the other MSM8916 device trees. However, it is actually used through
+ * arch/arm/boot/dts/qcom-msm8916-samsung-heatqlte.dts
+ */
+
+/ {
+	model = "Samsung Galaxy Ace 4 (SM-G357FZ)";
+	compatible = "samsung,heatqlte", "qcom,msm8916";
+	chassis-type = "handset";
+
+	reserved-memory {
+		mpss_mem: mpss@86800000 {
+			reg = <0x0 0x86800000 0x0 0x5000000>;
+			no-map;
+		};
+
+		gps_mem: gps@8b800000 {
+			reg = <0x0 0x8b800000 0x0 0x200000>;
+			no-map;
+		};
+	};
+};

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-heatqlte.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-heatqlte.dts
@@ -33,3 +33,7 @@
 		};
 	};
 };
+
+&panel {
+	compatible = "samsung,s6288a0";
+};

--- a/drivers/gpu/drm/panel/msm8916-generated/Makefile
+++ b/drivers/gpu/drm/panel/msm8916-generated/Makefile
@@ -22,6 +22,7 @@ obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-s6d7aa0-ltl101at01.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-s6e88a0-ams427ap24.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-s6e8aa5x01-ams497hy01.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-s6e8aa5x01-ams520kt01.o
+obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-sc7798a-bv045wvm.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-tc358764-ltl101al06.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-wingtech-auo-nt35521.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-wingtech-auo-r61308.o

--- a/drivers/gpu/drm/panel/msm8916-generated/Makefile
+++ b/drivers/gpu/drm/panel/msm8916-generated/Makefile
@@ -15,6 +15,7 @@ obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-ea8061-ams549bu19-id4
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-ea8061v-ams497ee01.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-hx8389c-gh9607501a.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-nt51017-b4p096wx5vp09.o
+obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-s6288a0.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-s6d2aa0x62-lpm053a250a.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-s6d78a0-gh9607501a.o
 obj-$(CONFIG_DRM_PANEL_MSM8916_GENERATED) += panel-samsung-s6d7aa0-lsl080al03.o

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-s6288a0.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-s6288a0.c
@@ -73,6 +73,7 @@ static int samsung_on(struct samsung *ctx)
 	dsi_dcs_write_seq(dsi, 0xb2, 0x40, 0x08, 0x20, 0x00, 0x08);
 	dsi_dcs_write_seq(dsi, 0xb6, 0x28, 0x0b);
 	dsi_dcs_write_seq(dsi, MIPI_DCS_WRITE_POWER_SAVE, 0x00);
+	dsi_dcs_write_seq(dsi, 0xf7, 0x03);
 	dsi_dcs_write_seq(dsi, 0xfc, 0xa5, 0xa5);
 
 	ret = mipi_dsi_dcs_set_display_on(dsi);

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-s6288a0.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-s6288a0.c
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2022 FIXME
+// Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
+//   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
+
+#include <linux/delay.h>
+#include <linux/gpio/consumer.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/regulator/consumer.h>
+
+#include <video/mipi_display.h>
+
+#include <drm/drm_mipi_dsi.h>
+#include <drm/drm_modes.h>
+#include <drm/drm_panel.h>
+
+struct samsung {
+	struct drm_panel panel;
+	struct mipi_dsi_device *dsi;
+	struct regulator_bulk_data supplies[2];
+	struct gpio_desc *reset_gpio;
+	bool prepared;
+};
+
+static inline struct samsung *to_samsung(struct drm_panel *panel)
+{
+	return container_of(panel, struct samsung, panel);
+}
+
+#define dsi_dcs_write_seq(dsi, seq...) do {				\
+		static const u8 d[] = { seq };				\
+		int ret;						\
+		ret = mipi_dsi_dcs_write_buffer(dsi, d, ARRAY_SIZE(d));	\
+		if (ret < 0)						\
+			return ret;					\
+	} while (0)
+
+static void samsung_reset(struct samsung *ctx)
+{
+	gpiod_set_value_cansleep(ctx->reset_gpio, 0);
+	usleep_range(5000, 6000);
+	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+	usleep_range(1000, 2000);
+	gpiod_set_value_cansleep(ctx->reset_gpio, 0);
+	usleep_range(10000, 11000);
+}
+
+static int samsung_on(struct samsung *ctx)
+{
+	struct mipi_dsi_device *dsi = ctx->dsi;
+	struct device *dev = &dsi->dev;
+	int ret;
+
+	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+
+	dsi_dcs_write_seq(dsi, 0xf0, 0x5a, 0x5a);
+	dsi_dcs_write_seq(dsi, 0xfc, 0x5a, 0x5a);
+
+	ret = mipi_dsi_dcs_exit_sleep_mode(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to exit sleep mode: %d\n", ret);
+		return ret;
+	}
+	msleep(120);
+
+	dsi_dcs_write_seq(dsi, 0xb8, 0x38, 0x0b, 0x30);
+	dsi_dcs_write_seq(dsi, 0xca,
+			  0x01, 0x00, 0x01, 0x00, 0x01, 0x00, 0x80, 0x80, 0x80,
+			  0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+			  0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+			  0x80, 0x80, 0x80, 0x00, 0x00, 0x00);
+	dsi_dcs_write_seq(dsi, 0xb2, 0x40, 0x08, 0x20, 0x00, 0x08);
+	dsi_dcs_write_seq(dsi, 0xb6, 0x28, 0x0b);
+	dsi_dcs_write_seq(dsi, MIPI_DCS_WRITE_POWER_SAVE, 0x00);
+	dsi_dcs_write_seq(dsi, 0xfc, 0xa5, 0xa5);
+
+	ret = mipi_dsi_dcs_set_display_on(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to set display on: %d\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int samsung_off(struct samsung *ctx)
+{
+	struct mipi_dsi_device *dsi = ctx->dsi;
+	struct device *dev = &dsi->dev;
+	int ret;
+
+	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
+
+	ret = mipi_dsi_dcs_set_display_off(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to set display off: %d\n", ret);
+		return ret;
+	}
+	msleep(35);
+
+	ret = mipi_dsi_dcs_enter_sleep_mode(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to enter sleep mode: %d\n", ret);
+		return ret;
+	}
+	msleep(120);
+
+	return 0;
+}
+
+static int samsung_prepare(struct drm_panel *panel)
+{
+	struct samsung *ctx = to_samsung(panel);
+	struct device *dev = &ctx->dsi->dev;
+	int ret;
+
+	if (ctx->prepared)
+		return 0;
+
+	ret = regulator_bulk_enable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+	if (ret < 0) {
+		dev_err(dev, "Failed to enable regulators: %d\n", ret);
+		return ret;
+	}
+
+	samsung_reset(ctx);
+
+	ret = samsung_on(ctx);
+	if (ret < 0) {
+		dev_err(dev, "Failed to initialize panel: %d\n", ret);
+		gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+		regulator_bulk_disable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+		return ret;
+	}
+
+	ctx->prepared = true;
+	return 0;
+}
+
+static int samsung_unprepare(struct drm_panel *panel)
+{
+	struct samsung *ctx = to_samsung(panel);
+	struct device *dev = &ctx->dsi->dev;
+	int ret;
+
+	if (!ctx->prepared)
+		return 0;
+
+	ret = samsung_off(ctx);
+	if (ret < 0)
+		dev_err(dev, "Failed to un-initialize panel: %d\n", ret);
+
+	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+	regulator_bulk_disable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+
+	ctx->prepared = false;
+	return 0;
+}
+
+static const struct drm_display_mode samsung_mode = {
+	.clock = (480 + 90 + 2 + 50) * (800 + 13 + 1 + 2) * 60 / 1000,
+	.hdisplay = 480,
+	.hsync_start = 480 + 90,
+	.hsync_end = 480 + 90 + 2,
+	.htotal = 480 + 90 + 2 + 50,
+	.vdisplay = 800,
+	.vsync_start = 800 + 13,
+	.vsync_end = 800 + 13 + 1,
+	.vtotal = 800 + 13 + 1 + 2,
+	.width_mm = 56,
+	.height_mm = 94,
+};
+
+static int samsung_get_modes(struct drm_panel *panel,
+			     struct drm_connector *connector)
+{
+	struct drm_display_mode *mode;
+
+	mode = drm_mode_duplicate(connector->dev, &samsung_mode);
+	if (!mode)
+		return -ENOMEM;
+
+	drm_mode_set_name(mode);
+
+	mode->type = DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED;
+	connector->display_info.width_mm = mode->width_mm;
+	connector->display_info.height_mm = mode->height_mm;
+	drm_mode_probed_add(connector, mode);
+
+	return 1;
+}
+
+static const struct drm_panel_funcs samsung_panel_funcs = {
+	.prepare = samsung_prepare,
+	.unprepare = samsung_unprepare,
+	.get_modes = samsung_get_modes,
+};
+
+static int samsung_probe(struct mipi_dsi_device *dsi)
+{
+	struct device *dev = &dsi->dev;
+	struct samsung *ctx;
+	int ret;
+
+	ctx = devm_kzalloc(dev, sizeof(*ctx), GFP_KERNEL);
+	if (!ctx)
+		return -ENOMEM;
+
+	ctx->supplies[0].supply = "vddio";
+	ctx->supplies[1].supply = "vdd";
+	ret = devm_regulator_bulk_get(dev, ARRAY_SIZE(ctx->supplies),
+				      ctx->supplies);
+	if (ret < 0)
+		return dev_err_probe(dev, ret, "Failed to get regulators\n");
+
+	ctx->reset_gpio = devm_gpiod_get(dev, "reset", GPIOD_OUT_HIGH);
+	if (IS_ERR(ctx->reset_gpio))
+		return dev_err_probe(dev, PTR_ERR(ctx->reset_gpio),
+				     "Failed to get reset-gpios\n");
+
+	ctx->dsi = dsi;
+	mipi_dsi_set_drvdata(dsi, ctx);
+
+	dsi->lanes = 2;
+	dsi->format = MIPI_DSI_FMT_RGB888;
+	dsi->mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST |
+			  MIPI_DSI_MODE_NO_EOT_PACKET;
+
+	drm_panel_init(&ctx->panel, dev, &samsung_panel_funcs,
+		       DRM_MODE_CONNECTOR_DSI);
+
+	drm_panel_add(&ctx->panel);
+
+	ret = mipi_dsi_attach(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to attach to DSI host: %d\n", ret);
+		drm_panel_remove(&ctx->panel);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int samsung_remove(struct mipi_dsi_device *dsi)
+{
+	struct samsung *ctx = mipi_dsi_get_drvdata(dsi);
+	int ret;
+
+	ret = mipi_dsi_detach(dsi);
+	if (ret < 0)
+		dev_err(&dsi->dev, "Failed to detach from DSI host: %d\n", ret);
+
+	drm_panel_remove(&ctx->panel);
+
+	return 0;
+}
+
+static const struct of_device_id samsung_of_match[] = {
+	{ .compatible = "samsung,s6288a0" }, // FIXME
+	{ /* sentinel */ }
+};
+MODULE_DEVICE_TABLE(of, samsung_of_match);
+
+static struct mipi_dsi_driver samsung_driver = {
+	.probe = samsung_probe,
+	.remove = samsung_remove,
+	.driver = {
+		.name = "panel-samsung",
+		.of_match_table = samsung_of_match,
+	},
+};
+module_mipi_dsi_driver(samsung_driver);
+
+MODULE_AUTHOR("linux-mdss-dsi-panel-driver-generator <fix@me>"); // FIXME
+MODULE_DESCRIPTION("DRM driver for Samsung WVGA video mode dsi panel");
+MODULE_LICENSE("GPL v2");

--- a/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-sc7798a-bv045wvm.c
+++ b/drivers/gpu/drm/panel/msm8916-generated/panel-samsung-sc7798a-bv045wvm.c
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2022 FIXME
+// Generated with linux-mdss-dsi-panel-driver-generator from vendor device tree:
+//   Copyright (c) 2013, The Linux Foundation. All rights reserved. (FIXME)
+
+#include <linux/backlight.h>
+#include <linux/delay.h>
+#include <linux/gpio/consumer.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/regulator/consumer.h>
+
+#include <video/mipi_display.h>
+
+#include <drm/drm_mipi_dsi.h>
+#include <drm/drm_modes.h>
+#include <drm/drm_panel.h>
+
+struct sc7798a_bv045wvm {
+	struct drm_panel panel;
+	struct mipi_dsi_device *dsi;
+	struct regulator_bulk_data supplies[2];
+	struct gpio_desc *reset_gpio;
+	bool prepared;
+};
+
+static inline
+struct sc7798a_bv045wvm *to_sc7798a_bv045wvm(struct drm_panel *panel)
+{
+	return container_of(panel, struct sc7798a_bv045wvm, panel);
+}
+
+#define dsi_dcs_write_seq(dsi, seq...) do {				\
+		static const u8 d[] = { seq };				\
+		int ret;						\
+		ret = mipi_dsi_dcs_write_buffer(dsi, d, ARRAY_SIZE(d));	\
+		if (ret < 0)						\
+			return ret;					\
+	} while (0)
+
+static void sc7798a_bv045wvm_reset(struct sc7798a_bv045wvm *ctx)
+{
+	gpiod_set_value_cansleep(ctx->reset_gpio, 0);
+	msleep(20);
+	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+	usleep_range(1000, 2000);
+	gpiod_set_value_cansleep(ctx->reset_gpio, 0);
+	msleep(150);
+}
+
+static int sc7798a_bv045wvm_on(struct sc7798a_bv045wvm *ctx)
+{
+	struct mipi_dsi_device *dsi = ctx->dsi;
+	struct device *dev = &dsi->dev;
+	int ret;
+
+	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+
+	dsi_dcs_write_seq(dsi, 0xb9, 0xf1, 0x08, 0x00);
+	dsi_dcs_write_seq(dsi, 0xb1, 0x31, 0x0c, 0x0c, 0xa7, 0x33, 0x01, 0xb7);
+	dsi_dcs_write_seq(dsi, 0xc6, 0x00, 0x00, 0xfd);
+	dsi_dcs_write_seq(dsi, 0xe3, 0x03, 0x03, 0x03, 0x03);
+	dsi_dcs_write_seq(dsi, 0xb8, 0x06, 0x22);
+	usleep_range(10000, 11000);
+	dsi_dcs_write_seq(dsi, 0xba,
+			  0x31, 0x00, 0x44, 0x25, 0x91, 0x0a, 0x00, 0x00, 0xc2,
+			  0x34, 0x00, 0x00, 0x04, 0x02, 0x1d, 0xb9, 0xee, 0x40);
+	dsi_dcs_write_seq(dsi, 0xb3,
+			  0x00, 0x00, 0x00, 0x00, 0x0c, 0x0a, 0x25, 0x20);
+	dsi_dcs_write_seq(dsi, 0xb4, 0x00);
+	dsi_dcs_write_seq(dsi, 0xcc, 0x0e);
+	dsi_dcs_write_seq(dsi, 0xbc, 0x67);
+	dsi_dcs_write_seq(dsi, 0xb2, 0x03);
+	dsi_dcs_write_seq(dsi, 0xc0, 0x73, 0x50, 0x00, 0x08, 0x70);
+	dsi_dcs_write_seq(dsi, 0xe9,
+			  0x00, 0x00, 0x06, 0x00, 0x00, 0x6e, 0x29, 0x12, 0x30,
+			  0x00, 0x48, 0x08, 0x6e, 0x29, 0x47, 0x03, 0x00, 0x00,
+			  0x00, 0x00, 0x00, 0x18, 0x00, 0x00, 0x89, 0x98, 0x33,
+			  0x11, 0x77, 0x55, 0x13, 0x00, 0x00, 0x89, 0x98, 0x22,
+			  0x00, 0x66, 0x44, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
+			  0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_dcs_write_seq(dsi, 0xea,
+			  0x00, 0x00, 0x98, 0x98, 0x44, 0x66, 0x00, 0x22, 0x20,
+			  0x00, 0x00, 0x98, 0x98, 0x55, 0x77, 0x11, 0x33, 0x31,
+			  0x30, 0x00, 0x00, 0xff, 0x01, 0x00, 0x00, 0x00, 0x00,
+			  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00);
+	dsi_dcs_write_seq(dsi, 0xe0,
+			  0x01, 0x09, 0x0d, 0x2e, 0x36, 0x3f, 0x10, 0x31, 0x07,
+			  0x0d, 0x11, 0x15, 0x13, 0x16, 0x15, 0x32, 0x38, 0x01,
+			  0x05, 0x05, 0x30, 0x35, 0x3f, 0x0e, 0x30, 0x04, 0x09,
+			  0x0a, 0x0d, 0x12, 0x0d, 0x0f, 0x2c, 0x35);
+	dsi_dcs_write_seq(dsi, 0xc7, 0xc0);
+	dsi_dcs_write_seq(dsi, 0xc8, 0x11, 0x01);
+	dsi_dcs_write_seq(dsi, MIPI_DCS_WRITE_CONTROL_DISPLAY, 0x24);
+
+	ret = mipi_dsi_dcs_exit_sleep_mode(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to exit sleep mode: %d\n", ret);
+		return ret;
+	}
+	msleep(120);
+
+	ret = mipi_dsi_dcs_set_display_on(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to set display on: %d\n", ret);
+		return ret;
+	}
+	usleep_range(10000, 11000);
+
+	return 0;
+}
+
+static int sc7798a_bv045wvm_off(struct sc7798a_bv045wvm *ctx)
+{
+	struct mipi_dsi_device *dsi = ctx->dsi;
+
+	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
+
+	dsi_dcs_write_seq(dsi, 0x28, 0x00);
+	msleep(70);
+	dsi_dcs_write_seq(dsi, 0x10, 0x00);
+	msleep(70);
+
+	return 0;
+}
+
+static int sc7798a_bv045wvm_prepare(struct drm_panel *panel)
+{
+	struct sc7798a_bv045wvm *ctx = to_sc7798a_bv045wvm(panel);
+	struct device *dev = &ctx->dsi->dev;
+	int ret;
+
+	if (ctx->prepared)
+		return 0;
+
+	ret = regulator_bulk_enable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+	if (ret < 0) {
+		dev_err(dev, "Failed to enable regulators: %d\n", ret);
+		return ret;
+	}
+
+	sc7798a_bv045wvm_reset(ctx);
+
+	ret = sc7798a_bv045wvm_on(ctx);
+	if (ret < 0) {
+		dev_err(dev, "Failed to initialize panel: %d\n", ret);
+		gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+		regulator_bulk_disable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+		return ret;
+	}
+
+	ctx->prepared = true;
+	return 0;
+}
+
+static int sc7798a_bv045wvm_unprepare(struct drm_panel *panel)
+{
+	struct sc7798a_bv045wvm *ctx = to_sc7798a_bv045wvm(panel);
+	struct device *dev = &ctx->dsi->dev;
+	int ret;
+
+	if (!ctx->prepared)
+		return 0;
+
+	ret = sc7798a_bv045wvm_off(ctx);
+	if (ret < 0)
+		dev_err(dev, "Failed to un-initialize panel: %d\n", ret);
+
+	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+	regulator_bulk_disable(ARRAY_SIZE(ctx->supplies), ctx->supplies);
+
+	ctx->prepared = false;
+	return 0;
+}
+
+static const struct drm_display_mode sc7798a_bv045wvm_mode = {
+	.clock = (480 + 140 + 4 + 132) * (800 + 10 + 4 + 12) * 60 / 1000,
+	.hdisplay = 480,
+	.hsync_start = 480 + 140,
+	.hsync_end = 480 + 140 + 4,
+	.htotal = 480 + 140 + 4 + 132,
+	.vdisplay = 800,
+	.vsync_start = 800 + 10,
+	.vsync_end = 800 + 10 + 4,
+	.vtotal = 800 + 10 + 4 + 12,
+	.width_mm = 62,
+	.height_mm = 106,
+};
+
+static int sc7798a_bv045wvm_get_modes(struct drm_panel *panel,
+				      struct drm_connector *connector)
+{
+	struct drm_display_mode *mode;
+
+	mode = drm_mode_duplicate(connector->dev, &sc7798a_bv045wvm_mode);
+	if (!mode)
+		return -ENOMEM;
+
+	drm_mode_set_name(mode);
+
+	mode->type = DRM_MODE_TYPE_DRIVER | DRM_MODE_TYPE_PREFERRED;
+	connector->display_info.width_mm = mode->width_mm;
+	connector->display_info.height_mm = mode->height_mm;
+	drm_mode_probed_add(connector, mode);
+
+	return 1;
+}
+
+static const struct drm_panel_funcs sc7798a_bv045wvm_panel_funcs = {
+	.prepare = sc7798a_bv045wvm_prepare,
+	.unprepare = sc7798a_bv045wvm_unprepare,
+	.get_modes = sc7798a_bv045wvm_get_modes,
+};
+
+static int sc7798a_bv045wvm_bl_update_status(struct backlight_device *bl)
+{
+	struct mipi_dsi_device *dsi = bl_get_data(bl);
+	u16 brightness = backlight_get_brightness(bl);
+	int ret;
+
+	dsi->mode_flags &= ~MIPI_DSI_MODE_LPM;
+
+	ret = mipi_dsi_dcs_set_display_brightness(dsi, brightness);
+	if (ret < 0)
+		return ret;
+
+	dsi->mode_flags |= MIPI_DSI_MODE_LPM;
+
+	return 0;
+}
+
+static const struct backlight_ops sc7798a_bv045wvm_bl_ops = {
+	.update_status = sc7798a_bv045wvm_bl_update_status,
+};
+
+static struct backlight_device *
+sc7798a_bv045wvm_create_backlight(struct mipi_dsi_device *dsi)
+{
+	struct device *dev = &dsi->dev;
+	const struct backlight_properties props = {
+		.type = BACKLIGHT_RAW,
+		.brightness = 255,
+		.max_brightness = 255,
+	};
+
+	return devm_backlight_device_register(dev, dev_name(dev), dev, dsi,
+					      &sc7798a_bv045wvm_bl_ops, &props);
+}
+
+static int sc7798a_bv045wvm_probe(struct mipi_dsi_device *dsi)
+{
+	struct device *dev = &dsi->dev;
+	struct sc7798a_bv045wvm *ctx;
+	int ret;
+
+	ctx = devm_kzalloc(dev, sizeof(*ctx), GFP_KERNEL);
+	if (!ctx)
+		return -ENOMEM;
+
+	ctx->supplies[0].supply = "vddio";
+	ctx->supplies[1].supply = "vdd";
+	ret = devm_regulator_bulk_get(dev, ARRAY_SIZE(ctx->supplies),
+				      ctx->supplies);
+	if (ret < 0)
+		return dev_err_probe(dev, ret, "Failed to get regulators\n");
+
+	ctx->reset_gpio = devm_gpiod_get(dev, "reset", GPIOD_OUT_HIGH);
+	if (IS_ERR(ctx->reset_gpio))
+		return dev_err_probe(dev, PTR_ERR(ctx->reset_gpio),
+				     "Failed to get reset-gpios\n");
+
+	ctx->dsi = dsi;
+	mipi_dsi_set_drvdata(dsi, ctx);
+
+	dsi->lanes = 2;
+	dsi->format = MIPI_DSI_FMT_RGB888;
+	dsi->mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST |
+			  MIPI_DSI_MODE_NO_EOT_PACKET |
+			  MIPI_DSI_CLOCK_NON_CONTINUOUS;
+
+	drm_panel_init(&ctx->panel, dev, &sc7798a_bv045wvm_panel_funcs,
+		       DRM_MODE_CONNECTOR_DSI);
+
+	ctx->panel.backlight = sc7798a_bv045wvm_create_backlight(dsi);
+	if (IS_ERR(ctx->panel.backlight))
+		return dev_err_probe(dev, PTR_ERR(ctx->panel.backlight),
+				     "Failed to create backlight\n");
+
+	drm_panel_add(&ctx->panel);
+
+	ret = mipi_dsi_attach(dsi);
+	if (ret < 0) {
+		dev_err(dev, "Failed to attach to DSI host: %d\n", ret);
+		drm_panel_remove(&ctx->panel);
+		return ret;
+	}
+
+	return 0;
+}
+
+static int sc7798a_bv045wvm_remove(struct mipi_dsi_device *dsi)
+{
+	struct sc7798a_bv045wvm *ctx = mipi_dsi_get_drvdata(dsi);
+	int ret;
+
+	ret = mipi_dsi_detach(dsi);
+	if (ret < 0)
+		dev_err(&dsi->dev, "Failed to detach from DSI host: %d\n", ret);
+
+	drm_panel_remove(&ctx->panel);
+
+	return 0;
+}
+
+static const struct of_device_id sc7798a_bv045wvm_of_match[] = {
+	{ .compatible = "samsung,sc7798a-bv045wvm" }, // FIXME
+	{ /* sentinel */ }
+};
+MODULE_DEVICE_TABLE(of, sc7798a_bv045wvm_of_match);
+
+static struct mipi_dsi_driver sc7798a_bv045wvm_driver = {
+	.probe = sc7798a_bv045wvm_probe,
+	.remove = sc7798a_bv045wvm_remove,
+	.driver = {
+		.name = "panel-sc7798a-bv045wvm",
+		.of_match_table = sc7798a_bv045wvm_of_match,
+	},
+};
+module_mipi_dsi_driver(sc7798a_bv045wvm_driver);
+
+MODULE_AUTHOR("linux-mdss-dsi-panel-driver-generator <fix@me>"); // FIXME
+MODULE_DESCRIPTION("DRM driver for SC7798A wvga video mode dsi panel");
+MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
Samsung Galaxy Ace 4 and Core Prime are phones based on MSM8916. They are
similar to the other Samsung devices based on MSM8916 with only a few
minor differences.

The device tree contains initial support for Ace 4 and Core Prime with:
- GPIO keys
- SDHCI (internal and external storage)
- USB Device Mode (on USB connector via the SM5504 MUIC)
- UART
- WCNSS (WiFi/BT)
- Regulators
- Vibration motor
- Sound and Modem
- Accelerometer
- NFC

Ace 4, Core Prime and Grand Prime are similar, with some differences in
MUIC, panel and touchscreen. The common parts are
shared in `msm8916-samsung-cprime-common.dtsi`
and `msm8916-samsung-gprime-common.dtsi` to reduce duplication.

Cc @eloydegen @garethppls