### PR TITLE
power: supply: smb1360: Fix IRQ_F_REG value

### DIFF
--- a/drivers/power/supply/smb1360.c
+++ b/drivers/power/supply/smb1360.c
@@ -192,7 +192,7 @@
 #define IRQ_E_USBIN_OV_BIT		BIT(2)
 #define IRQ_E_USBIN_UV_BIT		BIT(0)
 
-#define IRQ_F_REG			0x54
+#define IRQ_F_REG			0x55
 #define IRQ_F_OTG_OC_BIT		BIT(6)
 #define IRQ_F_OTG_FAIL_BIT		BIT(4)
 #define IRQ_F_POWER_OK_BIT		BIT(0)


### PR DESCRIPTION
The value assigned to IRQ_F_REG should be 0x55 as per downstream driver.
https://github.com/LineageOS/android_kernel_xiaomi_ferrari/blob/2368662e6a4fa4f5e3782666638e8f0f22bad650/drivers/power/smb1360-charger-fg.c#L195

Signed-off-by: Ketan Mate <kpmate94@gmail.com>