### PR TITLE
Add Nokia 8110, 6300 and 8000 4G (argon, leo, sparkler)

### DIFF
--- a/Documentation/devicetree/bindings/display/panel/panel-mipi-dbi-spi.yaml
+++ b/Documentation/devicetree/bindings/display/panel/panel-mipi-dbi-spi.yaml
@@ -22,8 +22,9 @@ description: |
   The standard defines the following interface signals for type C:
   - Power:
     - Vdd: Power supply for display module
+      Called power-supply in this binding.
     - Vddi: Logic level supply for interface signals
-    Combined into one in this binding called: power-supply
+      Called io-supply in this binding.
   - Interface:
     - CSx: Chip select
     - SCL: Serial clock
@@ -79,6 +80,11 @@ properties:
     description: |
       Controller data/command selection (D/CX) in 4-line SPI mode.
       If not set, the controller is in 3-line SPI mode.
+
+  io-supply:
+    description: |
+      Logic level supply for interface signals (Vddi).
+      No need to set if this is the same as power-supply.
 
 required:
   - compatible

--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -1051,6 +1051,8 @@ dtb-$(CONFIG_ARCH_QCOM) += \
 	qcom-msm8226-samsung-s3ve3g.dtb \
 	qcom-msm8660-surf.dtb \
 	qcom-msm8905-nokia-argon.dtb \
+	qcom-msm8909-nokia-leo.dtb \
+	qcom-msm8909-nokia-sparkler.dtb \
 	qcom-msm8916-samsung-e5.dtb \
 	qcom-msm8916-samsung-e7.dtb \
 	qcom-msm8916-samsung-fortunaltezt.dtb \

--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -1050,6 +1050,7 @@ dtb-$(CONFIG_ARCH_QCOM) += \
 	qcom-ipq8064-rb3011.dtb \
 	qcom-msm8226-samsung-s3ve3g.dtb \
 	qcom-msm8660-surf.dtb \
+	qcom-msm8905-nokia-argon.dtb \
 	qcom-msm8916-samsung-e5.dtb \
 	qcom-msm8916-samsung-e7.dtb \
 	qcom-msm8916-samsung-fortunaltezt.dtb \

--- a/arch/arm/boot/dts/qcom-msm8905-nokia-argon.dts
+++ b/arch/arm/boot/dts/qcom-msm8905-nokia-argon.dts
@@ -41,6 +41,25 @@
 		default-brightness-level = <10>;
 	};
 
+	bat: battery {
+		compatible = "simple-battery";
+		voltage-min-design-microvolt = <3400000>;
+		voltage-max-design-microvolt = <4400000>;
+		energy-full-design-microwatt-hours = <5850000>;
+		charge-full-design-microamp-hours = <1500000>;
+
+		ocv-capacity-celsius = <25>;
+		ocv-capacity-table-0 = <4380000 100>, <4292000 95>,
+			<4234000 90>, <4190000 85>, <4158000 80>, <4125000 75>,
+			<4090000 70>, <4040000 65>, <3988000 60>, <3950000 55>,
+			<3925000 50>, <3880000 45>, <3840000 40>, <3800000 35>,
+			<3784000 30>, <3761000 25>, <3743000 20>, <3722000 16>,
+			<3702000 13>, <3690000 11>, <3688000 10>, <3687000 9>,
+			<3685000 8>, <3683000 7>, <3677000 6>, <3656000 5>,
+			<3612000 4>, <3554000 3>, <3462000 2>, <3322000 1>,
+			<3000000 0>;
+	};
+
 	gpio-keys {
 		compatible = "gpio-keys";
 		pinctrl-names = "default";
@@ -174,6 +193,21 @@
 	status = "okay";
 };
 
+&pm8909_bms {
+	status = "okay";
+	monitored-battery = <&bat>;
+	power-supplies = <&pm8909_charger>;
+};
+
+&pm8909_charger {
+	status = "okay";
+
+	qcom,vdd-safe = <4350000>;
+	qcom,ibat-safe = <360000>;
+
+	monitored-battery = <&bat>;
+};
+
 &pm8909_pwm {
 	status = "okay";
 	pinctrl-names = "default";
@@ -183,10 +217,6 @@
 &pm8909_resin {
 	status = "okay";
 	linux,code = <KEY_DOWN>;
-};
-
-&pm8909_usbin {
-	status = "okay";
 };
 
 &pm8909_vib {
@@ -204,11 +234,11 @@
 
 &usb {
 	status = "okay";
-	extcon = <&pm8909_usbin>;
+	extcon = <&pm8909_charger>;
 };
 
 &usb_hs_phy {
-	extcon = <&pm8909_usbin>;
+	extcon = <&pm8909_charger>;
 };
 
 &pronto {

--- a/arch/arm/boot/dts/qcom-msm8905-nokia-argon.dts
+++ b/arch/arm/boot/dts/qcom-msm8905-nokia-argon.dts
@@ -1,0 +1,364 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/dts-v1/;
+#include "qcom-msm8909-pm8909.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
+#include <dt-bindings/pinctrl/qcom,pmic-mpp.h>
+
+/ {
+	model = "Nokia 8110 4G";
+	compatible = "nokia,argon", "qcom,msm8905", "qcom,msm8909";
+	chassis-type = "handset";
+
+	aliases {
+		serial0 = &blsp_uart1;
+	};
+
+	chosen {
+		stdout-path = "serial0";
+	};
+
+	reserved-memory {
+		/delete-node/ rmtfs@87c00000;
+		/* On downstream, this address is set by the bootloader */
+		rmtfs@9f700000 {
+			compatible = "qcom,rmtfs-mem";
+			reg = <0x9f700000 0x300000>;
+			no-map;
+
+			qcom,client-id = <1>;
+		};
+	};
+
+	backlight: backlight {
+		compatible = "pwm-backlight";
+		pwms = <&pm8909_pwm 0 100000>;
+
+		brightness-levels = <0 4 8 16 32 64 128 255>;
+		num-interpolated-steps = <2>;
+		default-brightness-level = <10>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		pinctrl-names = "default";
+		pinctrl-0 = <&gpio_key_active &lid_switch_active>;
+
+		key-up {
+			wakeup-source;
+			gpios = <&tlmm 90 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_UP>;
+			debounce-interval = <15>;
+			linux,can-disable;
+		};
+
+		key-back {
+			wakeup-source;
+			gpios = <&tlmm 98 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_BACKSPACE>;
+			debounce-interval = <15>;
+			linux,can-disable;
+		};
+
+		switch-lid-close {
+			wakeup-source;
+			gpios = <&tlmm 92 GPIO_ACTIVE_LOW>;
+			linux,input-type = <EV_SW>;
+			linux,code = <SW_LID>;
+		};
+
+		switch-lid-open {
+			gpios = <&tlmm 36 GPIO_ACTIVE_LOW>;
+			linux,input-type = <EV_SW>;
+			linux,code = <SW_KEYPAD_SLIDE>;
+		};
+	};
+
+	matrix_keypad: keypad {
+		compatible = "gpio-matrix-keypad";
+
+		col-scan-delay-ms = <7>;
+		debounce-delay-ms = <10>;
+		gpio-activelow;
+		pinctrl-names = "default";
+		pinctrl-0 = <&matrix_keypad_row_default &matrix_keypad_col_default>;
+
+		row-gpios = <&tlmm 97 GPIO_ACTIVE_LOW
+			&tlmm 96 GPIO_ACTIVE_LOW
+			&tlmm 95 GPIO_ACTIVE_LOW
+			&tlmm 94 GPIO_ACTIVE_LOW>;
+
+		col-gpios = <&tlmm 52 GPIO_ACTIVE_LOW
+			&tlmm 56 GPIO_ACTIVE_LOW
+			&tlmm 7 GPIO_ACTIVE_LOW
+			&tlmm 99 GPIO_ACTIVE_LOW
+			&tlmm 6 GPIO_ACTIVE_LOW>;
+
+		linux,keymap = <
+			MATRIX_KEY(0, 0, KEY_PICKUP_PHONE)
+			MATRIX_KEY(0, 1, KEY_1)
+			MATRIX_KEY(0, 2, KEY_4)
+			MATRIX_KEY(0, 3, KEY_7)
+			MATRIX_KEY(0, 4, KEY_NUMERIC_STAR)
+
+			MATRIX_KEY(1, 0, KEY_LEFT)
+			MATRIX_KEY(1, 1, KEY_2)
+			MATRIX_KEY(1, 2, KEY_5)
+			MATRIX_KEY(1, 3, KEY_8)
+			MATRIX_KEY(1, 4, KEY_0)
+
+			MATRIX_KEY(2, 0, BTN_LEFT)
+			MATRIX_KEY(2, 1, KEY_3)
+			MATRIX_KEY(2, 2, KEY_6)
+			MATRIX_KEY(2, 3, KEY_9)
+			MATRIX_KEY(2, 4, KEY_NUMERIC_POUND)
+
+			MATRIX_KEY(3, 0, KEY_ENTER)
+			MATRIX_KEY(3, 1, KEY_RIGHT)
+			MATRIX_KEY(3, 2, BTN_RIGHT)
+		>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&keypad_backlight_gpio>;
+
+		led-0 {
+			function = LED_FUNCTION_KBD_BACKLIGHT;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pm8909_gpios 1 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&blsp_spi5 {
+	status = "okay";
+	display@0 {
+		compatible = "nokia,argon-gc9305-v2-panel", "panel-mipi-dbi-spi";
+		reg = <0>;
+		backlight = <&backlight>;
+		reset-gpios = <&tlmm 25 GPIO_ACTIVE_HIGH>;
+		dc-gpios = <&tlmm 110 GPIO_ACTIVE_HIGH>;
+		spi-max-frequency = <50000000>;
+		power-supply = <&pm8909_l17>;
+		io-supply = <&pm8909_l6>;
+		width-mm = <36>;
+		height-mm = <48>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&panel_gpios_default>;
+
+		panel-timing {
+			hactive = <240>;
+			vactive = <320>;
+			hback-porch = <0>;
+			vback-porch = <0>;
+			hfront-porch = <0>;
+			vfront-porch = <0>;
+			hsync-len = <0>;
+			vsync-len = <0>;
+			clock-frequency = <(240 * 320 * 30)>; /* 30 fps */
+		};
+	};
+};
+
+&blsp_uart1 {
+	status = "okay";
+};
+
+&mpss {
+	status = "okay";
+};
+
+&pm8909_pwm {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm_out>;
+};
+
+&pm8909_resin {
+	status = "okay";
+	linux,code = <KEY_DOWN>;
+};
+
+&pm8909_usbin {
+	status = "okay";
+};
+
+&pm8909_vib {
+	status = "okay";
+};
+
+&sdhc_1 {
+	status = "okay";
+};
+
+&sdhc_2 {
+	status = "okay";
+	non-removable;
+};
+
+&usb {
+	status = "okay";
+	extcon = <&pm8909_usbin>;
+};
+
+&usb_hs_phy {
+	extcon = <&pm8909_usbin>;
+};
+
+&pronto {
+	status = "okay";
+};
+
+&smd_rpm_regulators {
+	s2 {
+		regulator-min-microvolt = <1850000>;
+		regulator-max-microvolt = <1850000>;
+	};
+
+	l1 {
+		regulator-min-microvolt = <1000000>;
+		regulator-max-microvolt = <1000000>;
+	};
+
+	l2 {
+		regulator-min-microvolt = <1200000>;
+		regulator-max-microvolt = <1200000>;
+	};
+
+	l4 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+	};
+
+	l5 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+	};
+
+	l6 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+	};
+
+	l7 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+	};
+
+	l8 {
+		regulator-min-microvolt = <2850000>;
+		regulator-max-microvolt = <2900000>;
+	};
+
+	l9 {
+		regulator-min-microvolt = <3000000>;
+		regulator-max-microvolt = <3300000>;
+	};
+
+	l10 {
+		regulator-min-microvolt = <1225000>;
+		regulator-max-microvolt = <1300000>;
+	};
+
+	l11 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <2950000>;
+		regulator-allow-set-load;
+		regulator-system-load = <200000>;
+	};
+
+	l12 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <2950000>;
+	};
+
+	l13 {
+		regulator-min-microvolt = <3075000>;
+		regulator-max-microvolt = <3075000>;
+	};
+
+	l14 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3000000>;
+	};
+
+	l15 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3000000>;
+	};
+
+	l17 {
+		regulator-min-microvolt = <2850000>;
+		regulator-max-microvolt = <2850000>;
+	};
+
+	l18 {
+		regulator-min-microvolt = <2700000>;
+		regulator-max-microvolt = <2700000>;
+	};
+};
+
+&pm8909_gpios {
+	keypad_backlight_gpio: keypad-backlight-gpio {
+		pins = "gpio1";
+		function = PMIC_GPIO_FUNC_NORMAL;
+
+		output-low;
+		power-source = <PM8916_GPIO_L5>;
+	};
+};
+
+&pm8909_mpps {
+	pwm_out: mpp2 {
+		pins = "mpp2";
+		function = "digital";
+
+		output-low;
+		qcom,dtest = <1>;
+		power-source = <PM8916_MPP_VPH>;
+	};
+};
+
+&tlmm {
+	gpio_key_active: gpio-key-active {
+		pins = "gpio90", "gpio98";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-pull-up;
+	};
+	lid_switch_active: lid-switch-active {
+		pins = "gpio36", "gpio92";
+		function = "gpio";
+
+		drive-strength = <6>;
+		bias-pull-up;
+	};
+	matrix_keypad_row_default: matrix-keypad-row-gpio {
+		pins = "gpio94", "gpio95", "gpio96", "gpio97";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-pull-up;
+	};
+	matrix_keypad_col_default: matrix-keypad-col-default {
+		pins = "gpio52", "gpio56", "gpio7", "gpio99", "gpio6";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+	panel_gpios_default: panel-gpios-default {
+		pins = "gpio24", "gpio25", "gpio110";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-pull-down;
+	};
+};

--- a/arch/arm/boot/dts/qcom-msm8909-nokia-leo-common.dtsi
+++ b/arch/arm/boot/dts/qcom-msm8909-nokia-leo-common.dtsi
@@ -50,6 +50,25 @@
 		default-brightness-level = <10>;
 	};
 
+	bat: battery {
+		compatible = "simple-battery";
+		voltage-min-design-microvolt = <3400000>;
+		voltage-max-design-microvolt = <4200000>;
+		energy-full-design-microwatt-hours = <5700000>;
+		charge-full-design-microamp-hours = <1500000>;
+
+		ocv-capacity-celsius = <25>;
+		ocv-capacity-table-0 = <4186000 100>, <4122000 95>,
+			<4078000 90>, <4033000 85>, <3982000 80>, <3958000 75>,
+			<3928000 70>, <3899000 65>, <3866000 60>, <3831000 55>,
+			<3808000 50>, <3793000 45>, <3782000 40>, <3775000 35>,
+			<3769000 30>, <3758000 25>, <3740000 20>, <3718000 16>,
+			<3696000 13>, <3689000 11>, <3688000 10>, <3687000 9>,
+			<3685000 8>, <3682000 7>, <3672000 6>, <3643000 5>,
+			<3596000 4>, <3532000 3>, <3448000 2>, <3315000 1>,
+			<3000000 0>;
+	};
+
 	gpio-keys {
 		compatible = "gpio-keys";
 		pinctrl-names = "default";
@@ -151,6 +170,21 @@
 	non-removable;
 };
 
+&pm8909_bms {
+	status = "okay";
+	monitored-battery = <&bat>;
+	power-supplies = <&pm8909_charger>;
+};
+
+&pm8909_charger {
+	status = "okay";
+
+	qcom,vdd-safe = <4150000>;
+	qcom,ibat-safe = <270000>;
+
+	monitored-battery = <&bat>;
+};
+
 &pm8909_pwm {
 	status = "okay";
 	pinctrl-names = "default";
@@ -162,17 +196,13 @@
 	linux,code = <KEY_NUMERIC_POUND>;
 };
 
-&pm8909_usbin {
-	status = "okay";
-};
-
 &usb {
 	status = "okay";
-	extcon = <&pm8909_usbin>;
+	extcon = <&pm8909_charger>;
 };
 
 &usb_hs_phy {
-	extcon = <&pm8909_usbin>;
+	extcon = <&pm8909_charger>;
 };
 
 &pronto {

--- a/arch/arm/boot/dts/qcom-msm8909-nokia-leo-common.dtsi
+++ b/arch/arm/boot/dts/qcom-msm8909-nokia-leo-common.dtsi
@@ -1,0 +1,321 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include "qcom-msm8909-pm8909.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
+#include <dt-bindings/pinctrl/qcom,pmic-mpp.h>
+
+/ {
+	aliases {
+		serial0 = &blsp_uart1;
+	};
+
+	chosen {
+		stdout-path = "serial0";
+	};
+
+	reserved-memory {
+		/delete-node/ rmtfs@87c00000;
+		/delete-node/ mpss@88000000;
+		/delete-node/ wcnss@8d500000;
+		reserved@84a00000 {
+			reg = <0x84a00000 0x400000>;
+			no-map;
+		};
+		mpss_mem: mpss@88000000 {
+			reg = <0x88000000 0x05000000>;
+			no-map;
+		};
+		wcnss_mem: wcnss@8d000000 {
+			reg = <0x8d000000 0x700000>;
+			no-map;
+		};
+		/* On downstream, this address is set by the bootloader */
+		rmtfs@9e900000 {
+			compatible = "qcom,rmtfs-mem";
+			reg = <0x9e900000 0x300000>;
+			no-map;
+
+			qcom,client-id = <1>;
+		};
+	};
+
+	backlight: backlight {
+		compatible = "pwm-backlight";
+		pwms = <&pm8909_pwm 0 100000>;
+
+		brightness-levels = <0 4 8 16 32 64 128 255>;
+		num-interpolated-steps = <2>;
+		default-brightness-level = <10>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		pinctrl-names = "default";
+		pinctrl-0 = <&gpio_key_active>;
+
+		key-star {
+			wakeup-source;
+			gpios = <&tlmm 90 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_NUMERIC_STAR>;
+			debounce-interval = <15>;
+			linux,can-disable;
+		};
+	};
+
+	matrix_keypad: keypad {
+		status = "disabled";
+		compatible = "gpio-matrix-keypad";
+
+		col-scan-delay-us = <7>;
+		debounce-delay-ms = <10>;
+		gpio-activelow;
+		pinctrl-names = "default";
+		pinctrl-0 = <&matrix_keypad_row_default &matrix_keypad_col_default>;
+
+		row-gpios = <&tlmm 97 GPIO_ACTIVE_LOW
+			&tlmm 96 GPIO_ACTIVE_LOW
+			&tlmm 95 GPIO_ACTIVE_LOW
+			&tlmm 94 GPIO_ACTIVE_LOW>;
+
+		col-gpios = <&tlmm 0 GPIO_ACTIVE_LOW
+			&tlmm 3 GPIO_ACTIVE_LOW
+			&tlmm 7 GPIO_ACTIVE_LOW
+			&tlmm 99 GPIO_ACTIVE_LOW
+			&tlmm 6 GPIO_ACTIVE_LOW
+			&tlmm 1 GPIO_ACTIVE_LOW>;
+
+		/* Specify linux,keypad in device dts */
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&keypad_backlight_gpio>;
+
+		led-0 {
+			function = LED_FUNCTION_KBD_BACKLIGHT;
+			color = <LED_COLOR_ID_WHITE>;
+			gpios = <&pm8909_gpios 1 GPIO_ACTIVE_HIGH>;
+		};
+	};
+};
+
+&blsp_spi5 {
+	status = "okay";
+	panel: display@0 {
+		status = "disabled";
+		/* Specify panel compatible and physical size in device dts */
+		compatible = "panel-mipi-dbi-spi";
+		reg = <0>;
+		backlight = <&backlight>;
+		reset-gpios = <&tlmm 25 GPIO_ACTIVE_HIGH>;
+		dc-gpios = <&tlmm 110 GPIO_ACTIVE_HIGH>;
+		spi-max-frequency = <50000000>;
+		power-supply = <&pm8909_l17>;
+		io-supply = <&pm8909_l6>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&panel_gpios_default>;
+
+		panel-timing {
+			hactive = <240>;
+			vactive = <320>;
+			hback-porch = <0>;
+			vback-porch = <0>;
+			hfront-porch = <0>;
+			vfront-porch = <0>;
+			hsync-len = <0>;
+			vsync-len = <0>;
+			clock-frequency = <(240 * 320 * 30)>; /* 30 fps */
+		};
+	};
+};
+
+&blsp_uart1 {
+	status = "okay";
+};
+
+&mpss {
+	status = "okay";
+};
+
+&sdhc_1 {
+	status = "okay";
+};
+
+&sdhc_2 {
+	status = "okay";
+	non-removable;
+};
+
+&pm8909_pwm {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm_out>;
+};
+
+&pm8909_resin {
+	status = "okay";
+	linux,code = <KEY_NUMERIC_POUND>;
+};
+
+&pm8909_usbin {
+	status = "okay";
+};
+
+&usb {
+	status = "okay";
+	extcon = <&pm8909_usbin>;
+};
+
+&usb_hs_phy {
+	extcon = <&pm8909_usbin>;
+};
+
+&pronto {
+	status = "okay";
+};
+
+&smd_rpm_regulators {
+	s2 {
+		regulator-min-microvolt = <1850000>;
+		regulator-max-microvolt = <1850000>;
+	};
+
+	l1 {
+		regulator-min-microvolt = <1000000>;
+		regulator-max-microvolt = <1000000>;
+	};
+
+	l2 {
+		regulator-min-microvolt = <1200000>;
+		regulator-max-microvolt = <1200000>;
+	};
+
+	l4 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+	};
+
+	l5 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+	};
+
+	l6 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+	};
+
+	l7 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+	};
+
+	l8 {
+		regulator-min-microvolt = <2850000>;
+		regulator-max-microvolt = <2900000>;
+	};
+
+	l9 {
+		regulator-min-microvolt = <3000000>;
+		regulator-max-microvolt = <3300000>;
+	};
+
+	l10 {
+		regulator-min-microvolt = <1225000>;
+		regulator-max-microvolt = <1300000>;
+	};
+
+	l11 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <2950000>;
+		regulator-allow-set-load;
+		regulator-system-load = <200000>;
+	};
+
+	l12 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <2950000>;
+	};
+
+	l13 {
+		regulator-min-microvolt = <3075000>;
+		regulator-max-microvolt = <3075000>;
+	};
+
+	l14 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3000000>;
+	};
+
+	l15 {
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <3000000>;
+	};
+
+	l17 {
+		regulator-min-microvolt = <2850000>;
+		regulator-max-microvolt = <2850000>;
+	};
+
+	l18 {
+		regulator-min-microvolt = <2700000>;
+		regulator-max-microvolt = <2700000>;
+	};
+};
+
+&pm8909_gpios {
+	keypad_backlight_gpio: keypad-backlight-gpio {
+		pins = "gpio1";
+		function = PMIC_GPIO_FUNC_NORMAL;
+
+		output-low;
+		power-source = <PM8916_GPIO_L2>;
+	};
+};
+
+&pm8909_mpps {
+	pwm_out: mpp2 {
+		pins = "mpp2";
+		function = "digital";
+
+		output-low;
+		qcom,dtest = <1>;
+		power-source = <PM8916_MPP_VPH>;
+	};
+};
+
+&tlmm {
+	gpio_key_active: gpio-key-active {
+		pins = "gpio90";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-pull-up;
+	};
+	matrix_keypad_row_default: matrix-keypad-row-default {
+		pins = "gpio94", "gpio95", "gpio96", "gpio97";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-pull-up;
+	};
+	matrix_keypad_col_default: matrix-keypad-col-default {
+		pins = "gpio0", "gpio3", "gpio7", "gpio99", "gpio6", "gpio1";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+	panel_gpios_default: panel-gpios-default {
+		pins = "gpio24", "gpio25", "gpio110";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-pull-down;
+	};
+};

--- a/arch/arm/boot/dts/qcom-msm8909-nokia-leo.dts
+++ b/arch/arm/boot/dts/qcom-msm8909-nokia-leo.dts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/dts-v1/;
+#include "qcom-msm8909-nokia-leo-common.dtsi"
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Nokia 6300 4G";
+	compatible = "nokia,leo", "qcom,msm8909";
+	chassis-type = "handset";
+};
+
+&matrix_keypad {
+	status = "okay";
+	linux,keymap = <
+		MATRIX_KEY(0, 0, BTN_LEFT)
+		MATRIX_KEY(0, 1, KEY_1)
+		MATRIX_KEY(0, 2, KEY_4)
+		MATRIX_KEY(0, 3, KEY_7)
+		MATRIX_KEY(0, 4, KEY_NUMERIC_STAR)
+		MATRIX_KEY(0, 5, KEY_PICKUP_PHONE)
+
+		MATRIX_KEY(1, 0, KEY_MENU)
+		MATRIX_KEY(1, 1, KEY_2)
+		MATRIX_KEY(1, 2, KEY_5)
+		MATRIX_KEY(1, 3, KEY_8)
+		MATRIX_KEY(1, 4, KEY_0)
+		MATRIX_KEY(1, 5, KEY_HANGUP_PHONE)
+
+		MATRIX_KEY(2, 0, KEY_LEFT)
+		MATRIX_KEY(2, 1, KEY_3)
+		MATRIX_KEY(2, 2, KEY_6)
+		MATRIX_KEY(2, 3, KEY_9)
+		MATRIX_KEY(2, 4, KEY_NUMERIC_POUND)
+		MATRIX_KEY(2, 5, BTN_RIGHT)
+
+		MATRIX_KEY(3, 0, KEY_DOWN)
+		MATRIX_KEY(3, 1, KEY_BACKSPACE)
+		MATRIX_KEY(3, 2, KEY_RIGHT)
+		MATRIX_KEY(3, 3, KEY_ENTER)
+		MATRIX_KEY(3, 4, KEY_UP)
+	>;
+};
+
+&panel {
+	status = "okay";
+	compatible = "nokia,leo-gc9305-hlt-24-panel", "panel-mipi-dbi-spi";
+	width-mm = <36>;
+	height-mm = <48>;
+};

--- a/arch/arm/boot/dts/qcom-msm8909-nokia-sparkler.dts
+++ b/arch/arm/boot/dts/qcom-msm8909-nokia-sparkler.dts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/dts-v1/;
+#include "qcom-msm8909-nokia-leo-common.dtsi"
+#include <dt-bindings/input/input.h>
+
+/ {
+	model = "Nokia 8000 4G";
+	compatible = "nokia,sparkler", "qcom,msm8909";
+	chassis-type = "handset";
+};
+
+&matrix_keypad {
+	status = "okay";
+	linux,keymap = <
+		MATRIX_KEY(0, 0, KEY_PICKUP_PHONE)
+		MATRIX_KEY(0, 1, KEY_1)
+		MATRIX_KEY(0, 2, KEY_4)
+		MATRIX_KEY(0, 3, KEY_7)
+		MATRIX_KEY(0, 4, KEY_NUMERIC_STAR)
+		MATRIX_KEY(0, 5, KEY_MENU)
+
+		MATRIX_KEY(1, 0, BTN_LEFT)
+		MATRIX_KEY(1, 1, KEY_2)
+		MATRIX_KEY(1, 2, KEY_5)
+		MATRIX_KEY(1, 3, KEY_8)
+		MATRIX_KEY(1, 4, KEY_0)
+		MATRIX_KEY(1, 5, KEY_BACKSPACE)
+
+		MATRIX_KEY(2, 0, KEY_LEFT)
+		MATRIX_KEY(2, 1, KEY_3)
+		MATRIX_KEY(2, 2, KEY_6)
+		MATRIX_KEY(2, 3, KEY_9)
+		MATRIX_KEY(2, 4, KEY_NUMERIC_POUND)
+		MATRIX_KEY(2, 5, KEY_HANGUP_PHONE)
+
+		MATRIX_KEY(3, 0, KEY_ENTER)
+		MATRIX_KEY(3, 1, BTN_RIGHT)
+		MATRIX_KEY(3, 2, KEY_RIGHT)
+		MATRIX_KEY(3, 3, KEY_UP)
+		MATRIX_KEY(3, 4, KEY_DOWN)
+	>;
+};
+
+&panel {
+	status = "okay";
+	compatible = "nokia,sparkler-gc9307-hlt-28-panel", "panel-mipi-dbi-spi";
+	width-mm = <42>;
+	height-mm = <56>;
+};

--- a/drivers/gpu/drm/drm_mipi_dbi.c
+++ b/drivers/gpu/drm/drm_mipi_dbi.c
@@ -427,6 +427,8 @@ void mipi_dbi_pipe_disable(struct drm_simple_display_pipe *pipe)
 
 	if (dbidev->regulator)
 		regulator_disable(dbidev->regulator);
+	if (dbidev->io_regulator)
+		regulator_disable(dbidev->io_regulator);
 }
 EXPORT_SYMBOL(mipi_dbi_pipe_disable);
 
@@ -652,6 +654,16 @@ static int mipi_dbi_poweron_reset_conditional(struct mipi_dbi_dev *dbidev, bool 
 		}
 	}
 
+	if (dbidev->io_regulator) {
+		ret = regulator_enable(dbidev->io_regulator);
+		if (ret) {
+			DRM_DEV_ERROR(dev, "Failed to enable I/O regulator (%d)\n", ret);
+			if (dbidev->regulator)
+				regulator_disable(dbidev->regulator);
+			return ret;
+		}
+	}
+
 	if (cond && mipi_dbi_display_is_on(dbi))
 		return 1;
 
@@ -661,6 +673,8 @@ static int mipi_dbi_poweron_reset_conditional(struct mipi_dbi_dev *dbidev, bool 
 		DRM_DEV_ERROR(dev, "Failed to send reset command (%d)\n", ret);
 		if (dbidev->regulator)
 			regulator_disable(dbidev->regulator);
+		if (dbidev->io_regulator)
+			regulator_disable(dbidev->io_regulator);
 		return ret;
 	}
 

--- a/drivers/gpu/drm/tiny/panel-mipi-dbi.c
+++ b/drivers/gpu/drm/tiny/panel-mipi-dbi.c
@@ -297,6 +297,11 @@ static int panel_mipi_dbi_spi_probe(struct spi_device *spi)
 		return dev_err_probe(dev, PTR_ERR(dbidev->regulator),
 				     "Failed to get regulator 'power'\n");
 
+	dbidev->io_regulator = devm_regulator_get(dev, "io");
+	if (IS_ERR(dbidev->io_regulator))
+		return dev_err_probe(dev, PTR_ERR(dbidev->io_regulator),
+				     "Failed to get regulator 'io'\n");
+
 	dbidev->backlight = devm_of_find_backlight(dev);
 	if (IS_ERR(dbidev->backlight))
 		return dev_err_probe(dev, PTR_ERR(dbidev->backlight), "Failed to get backlight\n");

--- a/include/drm/drm_mipi_dbi.h
+++ b/include/drm/drm_mipi_dbi.h
@@ -122,9 +122,14 @@ struct mipi_dbi_dev {
 	struct backlight_device *backlight;
 
 	/**
-	 * @regulator: power regulator (optional)
+	 * @regulator: power regulator (Vdd) (optional)
 	 */
 	struct regulator *regulator;
+
+	/**
+	 * @io_regulator: I/O power regulator (Vddi) (optional)
+	 */
+	struct regulator *io_regulator;
 
 	/**
 	 * @dbi: MIPI DBI interface


### PR DESCRIPTION
Add support for the Nokia 8110 4G (argon), Nokia 6300 4G (leo) and Nokia 8000 4G (sparkler).

Also add required PWM, vibrator, charger and battery nodes in qcom-pm8909.dtsi ~~and a new file qcom-msm8905.dtsi, which includes qcom-msm8909.dtsi and removes two CPU nodes because MSM8905 is just MSM8909 with two CPUs instead of four~~ (CPU removal is now handled in https://github.com/msm8916-mainline/lk2nd/pull/214).