### PR TITLE
UPSTREAM: arm64: dts: qcom: msm8916-samsung-grandmax: Add properties …

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-grandmax.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-grandmax.dts
@@ -29,8 +29,12 @@
 
 	gpio-leds {
 		compatible = "gpio-leds";
-		keyled {
+		led-keyled {
+			function = LED_FUNCTION_KBD_BACKLIGHT;
+			color = <LED_COLOR_ID_WHITE>;
+
 			gpios = <&msmgpio 60 GPIO_ACTIVE_HIGH>;
+
 			pinctrl-names = "default";
 			pinctrl-0 = <&gpio_leds_default>;
 		};


### PR DESCRIPTION
…function and color for keyled

keyled is white, and used as touchkey LEDs.
Add properties function and color for keyled.
http://lore.kernel.org/lkml/20221117144717.17886-1-linmengbo0689@protonmail.com/