### PR TITLE
FROMLIST: arm64: dts: qcom: msm8916-wingtech-wt88047: Add flash LED

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-wingtech-wt88047.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-wingtech-wt88047.dts
@@ -65,6 +65,20 @@
 		default-brightness-level = <255>;
 	};
 
+	flash-led-controller {
+		compatible = "ocs,ocp8110";
+		enable-gpios = <&msmgpio 31 GPIO_ACTIVE_HIGH>;
+		flash-gpios = <&msmgpio 32 GPIO_ACTIVE_HIGH>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&camera_flash_default>;
+
+		flash_led: led {
+			function = LED_FUNCTION_FLASH;
+			color = <LED_COLOR_ID_WHITE>;
+		};
+	};
+
 	gpio-keys {
 		compatible = "gpio-keys";
 
@@ -454,6 +468,14 @@
 };
 
 &msmgpio {
+	camera_flash_default: camera-flash-default-state {
+		pins = "gpio31", "gpio32";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
 	gpio_keys_default: gpio-keys-default {
 		pins = "gpio107";
 		function = "gpio";


### PR DESCRIPTION
WT88047 uses OCP 8110 Flash LED driver. Add it to the device tree.

https://lore.kernel.org/lkml/20221128051512.125148-1-linmengbo0689@protonmail.com/