### PR TITLE
dt-bindings: power: supply: smb1360: Fix missing space after comma

### DIFF
--- a/Documentation/devicetree/bindings/power/supply/smb1360.yaml
+++ b/Documentation/devicetree/bindings/power/supply/smb1360.yaml
@@ -72,7 +72,7 @@ properties:
     description:
       Specifies the battery profile to use.
       0 is for profile A, 1 is for profile B.
-    enum: [0,1]
+    enum: [0, 1]
 
   qcom,fg-batt-capacity-mah:
     $ref: /schemas/types.yaml#/definitions/uint32


### PR DESCRIPTION
Fix dt_binding_check warning due to missing space after a comma.

Signed-off-by: Vincent Knecht <vincent.knecht@mailoo.org>