### PR TITLE
arm64: dts: qcom: msm8916-samsung-e7: align TLMM pin configuration with DT schema

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-e2015-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-e2015-common.dtsi
@@ -82,6 +82,25 @@
 	};
 };
 
+&dsi0 {
+	panel: panel@0 {
+		reg = <0>;
+
+		reset-gpios = <&msmgpio 25 GPIO_ACTIVE_LOW>;
+
+		port {
+			panel_in: endpoint {
+				remote-endpoint = <&dsi0_out>;
+			};
+		};
+	};
+};
+
+&dsi0_out {
+	data-lanes = <0 1 2 3>;
+	remote-endpoint = <&panel_in>;
+};
+
 &reg_motor_vdd {
 	regulator-min-microvolt = <3300000>;
 	regulator-max-microvolt = <3300000>;

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-e2015-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-e2015-common.dtsi
@@ -82,25 +82,6 @@
 	};
 };
 
-&dsi0 {
-	panel: panel@0 {
-		reg = <0>;
-
-		reset-gpios = <&msmgpio 25 GPIO_ACTIVE_LOW>;
-
-		port {
-			panel_in: endpoint {
-				remote-endpoint = <&dsi0_out>;
-			};
-		};
-	};
-};
-
-&dsi0_out {
-	data-lanes = <0 1 2 3>;
-	remote-endpoint = <&panel_in>;
-};
-
 &reg_motor_vdd {
 	regulator-min-microvolt = <3300000>;
 	regulator-max-microvolt = <3300000>;

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-e7.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-e7.dts
@@ -34,6 +34,30 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&tsp_en_1p8_default>;
 	};
+
+	reg_vlcd_vdd3: regulator-vlcd-vdd3 {
+		compatible = "regulator-fixed";
+		regulator-name = "vlcd_vdd3";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		vin-supply = <&pm8916_s4>;
+
+		gpio = <&msmgpio 87 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&lcd_en_default>;
+	};
+
+	reg_vlcd_vci: regulator-vlcd-vci {
+		compatible = "regulator-fixed";
+		regulator-name = "vlcd_vci";
+		regulator-min-microvolt = <3000000>;
+		regulator-max-microvolt = <3000000>;
+
+		gpio = <&msmgpio 87 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+	};
 };
 
 &blsp_i2c5 {
@@ -57,12 +81,27 @@
 	};
 };
 
+&panel {
+	compatible = "samsung,e7-panel";
+
+	vdd3-supply = <&reg_vlcd_vdd3>;
+	vci-supply = <&reg_vlcd_vci>;
+};
+
 &pm8916_l17 {
 	regulator-min-microvolt = <3000000>;
 	regulator-max-microvolt = <3000000>;
 };
 
 &msmgpio {
+	lcd_en_default: lcd-en-default-state {
+		pins = "gpio87";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
+
 	tsp_en_1p8_default: tsp-en-1p8-default-state {
 		pins = "gpio60";
 		function = "gpio";

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-e7.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-e7.dts
@@ -34,30 +34,6 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&tsp_en_1p8_default>;
 	};
-
-	reg_vlcd_vdd3: regulator-vlcd-vdd3 {
-		compatible = "regulator-fixed";
-		regulator-name = "vlcd_vdd3";
-		regulator-min-microvolt = <1800000>;
-		regulator-max-microvolt = <1800000>;
-		vin-supply = <&pm8916_s4>;
-
-		gpio = <&msmgpio 87 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&lcd_en_default>;
-	};
-
-	reg_vlcd_vci: regulator-vlcd-vci {
-		compatible = "regulator-fixed";
-		regulator-name = "vlcd_vci";
-		regulator-min-microvolt = <3000000>;
-		regulator-max-microvolt = <3000000>;
-
-		gpio = <&msmgpio 87 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-	};
 };
 
 &blsp_i2c5 {
@@ -81,27 +57,12 @@
 	};
 };
 
-&panel {
-	compatible = "samsung,e7-panel";
-
-	vdd3-supply = <&reg_vlcd_vdd3>;
-	vci-supply = <&reg_vlcd_vci>;
-};
-
 &pm8916_l17 {
 	regulator-min-microvolt = <3000000>;
 	regulator-max-microvolt = <3000000>;
 };
 
 &msmgpio {
-	lcd_en_default: lcd-en-default {
-		pins = "gpio87";
-		function = "gpio";
-
-		drive-strength = <2>;
-		bias-disable;
-	};
-
 	tsp_en_1p8_default: tsp-en-1p8-default {
 		pins = "gpio60";
 		function = "gpio";

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-e7.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-e7.dts
@@ -21,9 +21,53 @@
 	model = "Samsung Galaxy E7";
 	compatible = "samsung,e7", "qcom,msm8916";
 	chassis-type = "handset";
+
+	reg_vdd_tsp: regulator-vdd-tsp {
+		compatible = "regulator-fixed";
+		regulator-name = "vdd_tsp";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+
+		gpio = <&msmgpio 60 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&tsp_en_1p8_default>;
+	};
+};
+
+&blsp_i2c5 {
+	status = "okay";
+
+	touchscreen@49 {
+		compatible = "st,stmfts";
+		reg = <0x49>;
+
+		interrupt-parent = <&msmgpio>;
+		interrupts = <13 IRQ_TYPE_EDGE_FALLING>;
+
+		touchscreen-size-x = <720>;
+		touchscreen-size-y = <1280>;
+
+		avdd-supply = <&reg_vdd_tsp_a>;
+		vdd-supply = <&reg_vdd_tsp>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&ts_int_default>;
+	};
 };
 
 &pm8916_l17 {
 	regulator-min-microvolt = <3000000>;
 	regulator-max-microvolt = <3000000>;
+};
+
+&msmgpio {
+	tsp_en_1p8_default: tsp-en-1p8-default-state {
+		pins = "gpio60";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-disable;
+	};
 };

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-e7.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-e7.dts
@@ -21,53 +21,9 @@
 	model = "Samsung Galaxy E7";
 	compatible = "samsung,e7", "qcom,msm8916";
 	chassis-type = "handset";
-
-	reg_vdd_tsp: regulator-vdd-tsp {
-		compatible = "regulator-fixed";
-		regulator-name = "vdd_tsp";
-		regulator-min-microvolt = <1800000>;
-		regulator-max-microvolt = <1800000>;
-
-		gpio = <&msmgpio 60 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&tsp_en_1p8_default>;
-	};
-};
-
-&blsp_i2c5 {
-	status = "okay";
-
-	touchscreen@49 {
-		compatible = "st,stmfts";
-		reg = <0x49>;
-
-		interrupt-parent = <&msmgpio>;
-		interrupts = <13 IRQ_TYPE_EDGE_FALLING>;
-
-		touchscreen-size-x = <720>;
-		touchscreen-size-y = <1280>;
-
-		avdd-supply = <&reg_vdd_tsp_a>;
-		vdd-supply = <&reg_vdd_tsp>;
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&ts_int_default>;
-	};
 };
 
 &pm8916_l17 {
 	regulator-min-microvolt = <3000000>;
 	regulator-max-microvolt = <3000000>;
-};
-
-&msmgpio {
-	tsp_en_1p8_default: tsp-en-1p8-default {
-		pins = "gpio60";
-		function = "gpio";
-
-		drive-strength = <2>;
-		bias-disable;
-	};
 };


### PR DESCRIPTION
DT schema expects TLMM pin configuration nodes to be named with
'-state' suffix and their optional children with '-pins' suffix.

Ref: 8b276ca036377a5baa4fd0692b80608f0de8a260