### PR TITLE
arm64: dts: qcom: msm8916-samsung-grandmax: New DT schema

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-grandmax.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-grandmax.dts
@@ -39,6 +39,58 @@
 			pinctrl-0 = <&gpio_leds_default>;
 		};
 	};
+
+	reg_vlcd_vcc: regulator-vlcd-vcc {
+		compatible = "regulator-fixed";
+		regulator-name = "vlcd_vcc";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+
+		gpio = <&msmgpio 16 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+
+		pinctrl-0 = <&lcd_on_default>;
+		pinctrl-names = "default";
+	};
+
+	reg_vsp: regulator-vsp {
+		compatible = "regulator-fixed";
+		regulator-name = "reg-vsp";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&msmgpio 97 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+
+		pinctrl-0 = <&lcd_enp_default>;
+		pinctrl-names = "default";
+	};
+
+	reg_vsn: regulator-vsn {
+		compatible = "regulator-fixed";
+		regulator-name = "reg-vsn";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+
+		gpio = <&msmgpio 120 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+
+		pinctrl-0 = <&lcd_enn_default>;
+		pinctrl-names = "default";
+	};
+};
+
+&panel {
+	compatible = "samsung,s6d2aa0x62-lpm053a250a";
+
+	vcc-supply = <&reg_vlcd_vcc>;
+	vsp-supply = <&reg_vsp>;
+	vsn-supply = <&reg_vsn>;
+
+	backlight-gpios = <&msmgpio 98 GPIO_ACTIVE_HIGH>;
+
+	pinctrl-0 = <&lcd_bl_en_default>;
+	pinctrl-names = "default";
 };
 
 &blsp_i2c5 {
@@ -75,6 +127,34 @@
 		pins = "gpio60";
 		function = "gpio";
 
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	lcd_bl_en_default: lcd-bl-en-default-state {
+		pins = "gpio98";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	lcd_enp_default: lcd-enp-default-state {
+		pins = "gpio97";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	lcd_enn_default: lcd-enn-default-state {
+		pins = "gpio120";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	lcd_on_default: lcd-on-default-state {
+		pins = "gpio16";
+		function = "gpio";
 		drive-strength = <2>;
 		bias-disable;
 	};

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-grandmax.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-grandmax.dts
@@ -93,27 +93,6 @@
 	pinctrl-0 = <&lcd_bl_en_default>;
 };
 
-&blsp_i2c5 {
-	status = "okay";
-
-	touchscreen@50 {
-		compatible = "imagis,ist3038";
-		reg = <0x50>;
-
-		interrupt-parent = <&msmgpio>;
-		interrupts = <13 IRQ_TYPE_EDGE_FALLING>;
-
-		touchscreen-size-x = <720>;
-		touchscreen-size-y = <1280>;
-
-		vdd-supply = <&reg_vdd_tsp_a>;
-		vddio-supply = <&pm8916_l6>;
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&ts_int_default>;
-	};
-};
-
 &reg_motor_vdd {
 	gpio = <&msmgpio 72 GPIO_ACTIVE_HIGH>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-grandmax.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-grandmax.dts
@@ -41,6 +41,27 @@
 	};
 };
 
+&blsp_i2c5 {
+	status = "okay";
+
+	touchscreen@50 {
+		compatible = "imagis,ist3038";
+		reg = <0x50>;
+
+		interrupt-parent = <&msmgpio>;
+		interrupts = <13 IRQ_TYPE_EDGE_FALLING>;
+
+		touchscreen-size-x = <720>;
+		touchscreen-size-y = <1280>;
+
+		vdd-supply = <&reg_vdd_tsp_a>;
+		vddio-supply = <&pm8916_l6>;
+
+		pinctrl-0 = <&ts_int_default>;
+		pinctrl-names = "default";
+	};
+};
+
 &reg_motor_vdd {
 	gpio = <&msmgpio 72 GPIO_ACTIVE_HIGH>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-grandmax.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-grandmax.dts
@@ -39,58 +39,6 @@
 			pinctrl-0 = <&gpio_leds_default>;
 		};
 	};
-
-	reg_vlcd_vcc: regulator-vlcd-vcc {
-		compatible = "regulator-fixed";
-		regulator-name = "vlcd_vcc";
-		regulator-min-microvolt = <1800000>;
-		regulator-max-microvolt = <1800000>;
-
-		gpio = <&msmgpio 16 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&lcd_on_default>;
-	};
-
-	reg_vsp: regulator-vsp {
-		compatible = "regulator-fixed";
-		regulator-name = "reg-vsp";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-
-		gpio = <&msmgpio 97 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&lcd_enp_default>;
-	};
-
-	reg_vsn: regulator-vsn {
-		compatible = "regulator-fixed";
-		regulator-name = "reg-vsn";
-		regulator-min-microvolt = <5000000>;
-		regulator-max-microvolt = <5000000>;
-
-		gpio = <&msmgpio 120 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-
-		pinctrl-names = "default";
-		pinctrl-0 = <&lcd_enn_default>;
-	};
-};
-
-&panel {
-	compatible = "samsung,s6d2aa0x62-lpm053a250a";
-
-	vcc-supply = <&reg_vlcd_vcc>;
-	vsp-supply = <&reg_vsp>;
-	vsn-supply = <&reg_vsn>;
-
-	backlight-gpios = <&msmgpio 98 GPIO_ACTIVE_HIGH>;
-
-	pinctrl-names = "default";
-	pinctrl-0 = <&lcd_bl_en_default>;
 };
 
 &reg_motor_vdd {
@@ -104,38 +52,6 @@
 &msmgpio {
 	gpio_leds_default: gpio-led-default-state {
 		pins = "gpio60";
-		function = "gpio";
-
-		drive-strength = <2>;
-		bias-disable;
-	};
-
-	lcd_bl_en_default: lcd-bl-en-default {
-		pins = "gpio98";
-		function = "gpio";
-
-		drive-strength = <2>;
-		bias-disable;
-	};
-
-	lcd_enp_default: lcd-enp-default {
-		pins = "gpio97";
-		function = "gpio";
-
-		drive-strength = <2>;
-		bias-disable;
-	};
-
-	lcd_enn_default: lcd-enn-default {
-		pins = "gpio120";
-		function = "gpio";
-
-		drive-strength = <2>;
-		bias-disable;
-	};
-
-	lcd_on_default: lcd-on-default {
-		pins = "gpio16";
 		function = "gpio";
 
 		drive-strength = <2>;


### PR DESCRIPTION
DT schema expects TLMM pin configuration nodes to be named with
'-state' suffix and their optional children with '-pins' suffix.

Ref: 8b276ca
https://lore.kernel.org/lkml/20230109110107.3016323-3-nikita@trvn.ru/
https://lore.kernel.org/lkml/20230109110107.3016323-4-nikita@trvn.ru/

Resort commits in addition.