### PR TITLE
arm64: dts: qcom: msm8916-samsung-fortuna/rossa: Upstreaming

### DIFF
--- a/arch/arm/boot/dts/qcom/Makefile
+++ b/arch/arm/boot/dts/qcom/Makefile
@@ -35,7 +35,9 @@ dtb-$(CONFIG_ARCH_QCOM) += \
 	qcom-msm8909-nokia-sparkler.dtb \
 	qcom-msm8916-samsung-e5.dtb \
 	qcom-msm8916-samsung-e7.dtb \
+	qcom-msm8916-samsung-fortunaltezt.dtb \
 	qcom-msm8916-samsung-grandmax.dtb \
+	qcom-msm8916-samsung-heatqlte.dtb \
 	qcom-msm8916-samsung-serranove.dtb \
 	qcom-msm8926-htc-memul.dtb \
 	qcom-msm8926-microsoft-superman-lte.dtb \

--- a/arch/arm/boot/dts/qcom/qcom-msm8916-samsung-fortunaltezt.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8916-samsung-fortunaltezt.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include "arm64/qcom/msm8916-samsung-fortunaltezt.dts"
+#include "qcom-msm8916-smp.dtsi"
+
+&tsens {
+	/* FIXME: The device crashes when accessing the SROT region for some reason */
+	status = "disabled";
+};

--- a/arch/arm/boot/dts/qcom/qcom-msm8916-samsung-fortunaltezt.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8916-samsung-fortunaltezt.dts
@@ -4,5 +4,5 @@
 
 &tsens {
 	/* FIXME: The device crashes when accessing the SROT region for some reason */
-	status = "disabled";
+	qcom,srot-locked;
 };

--- a/arch/arm/boot/dts/qcom/qcom-msm8916-samsung-heatqlte.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8916-samsung-heatqlte.dts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include "arm64/qcom/msm8916-samsung-heatqlte.dts"
+#include "qcom-msm8916-smp.dtsi"
+
+&tsens {
+	/* FIXME: The device crashes when accessing the SROT region for some reason */
+	status = "disabled";
+};

--- a/arch/arm/boot/dts/qcom/qcom-msm8916-samsung-heatqlte.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8916-samsung-heatqlte.dts
@@ -4,5 +4,5 @@
 
 &tsens {
 	/* FIXME: The device crashes when accessing the SROT region for some reason */
-	status = "disabled";
+	qcom,srot-locked;
 };

--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -48,6 +48,7 @@ dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-a5-zt.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-a5u-eur.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-e5.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-e7.dtb
+dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-fortunaltezt.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-gprimeltecan.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-grandmax.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-grandprimelte.dtb

--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -54,6 +54,7 @@ dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-grandmax.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-grandprimelte.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-gt510.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-gt58.dtb
+dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-heatqlte.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-j3ltetw.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-j5.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-j5x.dtb

--- a/arch/arm64/boot/dts/qcom/msm8216-samsung-fortuna3g.dts
+++ b/arch/arm64/boot/dts/qcom/msm8216-samsung-fortuna3g.dts
@@ -6,7 +6,7 @@
 
 / {
 	model = "Samsung Galaxy Grand Prime (SM-G530H)";
-	compatible = "samsung,fortuna3g", "qcom,msm8916";
+	compatible = "samsung,fortuna3g", "samsung,fortuna", "qcom,msm8916";
 	chassis-type = "handset";
 };
 

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-fortuna-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-fortuna-common.dtsi
@@ -262,6 +262,8 @@
 
 		pinctrl-0 = <&tsp_int_default>;
 		pinctrl-names = "default";
+
+		linux,keycodes = <KEY_APPSELECT KEY_BACK>;
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-fortuna-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-fortuna-common.dtsi
@@ -360,6 +360,16 @@
 	reg = <0x0 0x86800000 0x0 0x5000000>;
 };
 
+&pm8916_codec {
+	jack-gpios = <&tlmm 110 GPIO_ACTIVE_LOW>;
+	qcom,micbias-lvl = <2800>;
+	qcom,mbhc-vthreshold-low = <75 150 237 450 500>;
+	qcom,mbhc-vthreshold-high = <75 150 237 450 500>;
+
+	pinctrl-0 = <&jack_default>;
+	pinctrl-names = "default";
+};
+
 &pm8916_resin {
 	linux,code = <KEY_VOLUMEDOWN>;
 	status = "okay";
@@ -455,6 +465,13 @@
 		function = "gpio";
 		drive-strength = <2>;
 		bias-pull-up;
+	};
+
+	jack_default: jack-default-state {
+		pins = "gpio110";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
 	};
 
 	lcd_on_default: lcd-on-default-state {

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-fortuna-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-fortuna-common.dtsi
@@ -112,6 +112,21 @@
 
 			status = "disabled";
 		};
+
+		pn547_nfc: nfc@2b {
+			compatible = "nxp,pn547", "nxp,nxp-nci-i2c";
+			reg = <0x2b>;
+
+			interrupts-extended = <&tlmm 21 IRQ_TYPE_EDGE_RISING>;
+
+			enable-gpios = <&tlmm 20 GPIO_ACTIVE_HIGH>;
+			firmware-gpios = <&tlmm 49 GPIO_ACTIVE_HIGH>;
+
+			pinctrl-0 = <&nfc_default>;
+			pinctrl-names = "default";
+
+			status = "disabled";
+		};
 	};
 
 	reg_motor_vdd: regulator-motor-vdd {

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-fortuna-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-fortuna-common.dtsi
@@ -127,6 +127,19 @@
 		pinctrl-names = "default";
 	};
 
+	reg_vdd_lcd: regulator-vdd-lcd {
+		compatible = "regulator-fixed";
+		regulator-name = "vdd_lcd";
+		regulator-min-microvolt = <3000000>;
+		regulator-max-microvolt = <3000000>;
+
+		gpio = <&tlmm 102 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+
+		pinctrl-0 = <&lcd_on_default>;
+		pinctrl-names = "default";
+	};
+
 	reg_vdd_tsp_a: regulator-vdd-tsp-a {
 		compatible = "regulator-fixed";
 		regulator-name = "vdd_tsp_a";
@@ -307,6 +320,42 @@
 	status = "okay";
 };
 
+&gpu {
+	status = "okay";
+};
+
+&mdss {
+	status = "okay";
+};
+
+&mdss_dsi0 {
+	pinctrl-0 = <&mdss_default>;
+	pinctrl-1 = <&mdss_sleep>;
+	pinctrl-names = "default", "sleep";
+
+	panel: panel@0 {
+		compatible = "samsung,gprime-panel";
+		reg = <0>;
+
+		vddio-supply = <&pm8916_l6>;
+		vdd-supply = <&reg_vdd_lcd>;
+
+		reset-gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
+		backlight = <&clk_pwm_backlight>;
+
+		port {
+			panel_in: endpoint {
+				remote-endpoint = <&mdss_dsi0_out>;
+			};
+		};
+	};
+};
+
+&mdss_dsi0_out {
+	data-lanes = <0 1>;
+	remote-endpoint = <&panel_in>;
+};
+
 &mpss_mem {
 	reg = <0x0 0x86800000 0x0 0x5000000>;
 };
@@ -406,6 +455,27 @@
 		function = "gpio";
 		drive-strength = <2>;
 		bias-pull-up;
+	};
+
+	lcd_on_default: lcd-on-default-state {
+		pins = "gpio102";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	mdss_default: mdss-default-state {
+		pins = "gpio25";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	mdss_sleep: mdss-sleep-state {
+		pins = "gpio25";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-pull-down;
 	};
 
 	motor_en_default: motor-en-default-state {

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
@@ -37,6 +37,13 @@
 	status = "disabled";
 };
 
+&panel {
+	/* Actually hx8389c without PWM. There is no other variant */
+	compatible = "samsung,hx8389c-gh9607501a";
+
+	/delete-property/ backlight;
+};
+
 &pn547_nfc {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include "msm8916-samsung-fortuna-common.dtsi"
+
+/*
+ * NOTE: The original firmware from Samsung can only boot ARM32 kernels.
+ * Unfortunately, the firmware is signed and cannot be replaced easily.
+ * There seems to be no way to boot ARM64 kernels on this device at the moment,
+ * even though the hardware would support it.
+ *
+ * However, it is possible to use this device tree by compiling an ARM32 kernel
+ * instead. For clarity and build testing this device tree is maintained next
+ * to the other MSM8916 device trees. However, it is actually used through
+ * arch/arm/boot/dts/qcom-msm8916-samsung-fortunaltezt.dts
+ */
+
+/ {
+	model = "Samsung Galaxy Grand Prime (SM-G530Y)";
+	compatible = "samsung,fortunaltezt", "samsung,fortuna", "qcom,msm8916";
+	chassis-type = "handset";
+};
+
+/* On fortunaltezt backlight is controlled with MIPI DCS commands */
+&clk_pwm {
+	status = "disabled";
+};
+
+&clk_pwm_backlight {
+	status = "disabled";
+};

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
@@ -22,6 +22,12 @@
 	chassis-type = "handset";
 };
 
+&battery {
+	charge-term-current-microamp = <200000>;
+	constant-charge-current-max-microamp = <1000000>;
+	constant-charge-voltage-max-microvolt = <4350000>;
+};
+
 /* On fortunaltezt backlight is controlled with MIPI DCS commands */
 &clk_pwm {
 	status = "disabled";

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
@@ -37,6 +37,10 @@
 	status = "disabled";
 };
 
+&pn547_nfc {
+	status = "okay";
+};
+
 &st_accel {
 	compatible = "st,lis2hh12";
 	mount-matrix = "1",  "0", "0",

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
@@ -36,3 +36,11 @@
 &clk_pwm_backlight {
 	status = "disabled";
 };
+
+&st_accel {
+	compatible = "st,lis2hh12";
+	mount-matrix = "1",  "0", "0",
+		       "0", "-1", "0",
+		       "0",  "0", "1";
+	status = "okay";
+};

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprimeltecan.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprimeltecan.dts
@@ -6,7 +6,7 @@
 
 / {
 	model = "Samsung Galaxy Grand Prime (SM-G530W)";
-	compatible = "samsung,gprimeltecan", "qcom,msm8916";
+	compatible = "samsung,gprimeltecan", "samsung,fortuna", "qcom,msm8916";
 	chassis-type = "handset";
 
 	reserved-memory {

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-grandprimelte.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-grandprimelte.dts
@@ -6,7 +6,7 @@
 
 / {
 	model = "Samsung Galaxy Grand Prime (SM-G530FZ)";
-	compatible = "samsung,grandprimelte", "qcom,msm8916";
+	compatible = "samsung,grandprimelte", "samsung,fortuna", "qcom,msm8916";
 	chassis-type = "handset";
 };
 

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-heatqlte.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-heatqlte.dts
@@ -21,3 +21,9 @@
 	compatible = "samsung,heatqlte", "qcom,msm8916";
 	chassis-type = "handset";
 };
+
+&battery {
+	charge-term-current-microamp = <150000>;
+	constant-charge-current-max-microamp = <700000>;
+	constant-charge-voltage-max-microvolt = <4350000>;
+};

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-heatqlte.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-heatqlte.dts
@@ -27,3 +27,7 @@
 	constant-charge-current-max-microamp = <700000>;
 	constant-charge-voltage-max-microvolt = <4350000>;
 };
+
+&panel {
+	compatible = "samsung,s6288a0";
+};

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-heatqlte.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-heatqlte.dts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include "msm8916-samsung-rossa-common.dtsi"
+
+/*
+ * NOTE: The original firmware from Samsung can only boot ARM32 kernels.
+ * Unfortunately, the firmware is signed and cannot be replaced easily.
+ * There seems to be no way to boot ARM64 kernels on this device at the moment,
+ * even though the hardware would support it.
+ *
+ * However, it is possible to use this device tree by compiling an ARM32 kernel
+ * instead. For clarity and build testing this device tree is maintained next
+ * to the other MSM8916 device trees. However, it is actually used through
+ * arch/arm/boot/dts/qcom-msm8916-samsung-heatqlte.dts
+ */
+
+/ {
+	model = "Samsung Galaxy Ace 4 (SM-G357FZ)";
+	compatible = "samsung,heatqlte", "qcom,msm8916";
+	chassis-type = "handset";
+};

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-rossa-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-rossa-common.dtsi
@@ -33,6 +33,10 @@
 	status = "disabled";
 };
 
+&panel {
+	/delete-property/ backlight;
+};
+
 &s3fwrn5_nfc {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-rossa.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-rossa.dts
@@ -16,6 +16,26 @@
 	constant-charge-voltage-max-microvolt = <4400000>;
 };
 
+&blsp_i2c5 {
+	touchscreen@50 {
+		compatible = "imagis,ist3038";
+		reg = <0x50>;
+
+		interrupts-extended = <&tlmm 13 IRQ_TYPE_EDGE_FALLING>;
+
+		touchscreen-size-x = <480>;
+		touchscreen-size-y = <800>;
+
+		vdd-supply = <&reg_vdd_tsp_a>;
+		vddio-supply = <&pm8916_l6>;
+
+		pinctrl-0 = <&tsp_int_default>;
+		pinctrl-names = "default";
+
+		linux,keycodes = <KEY_APPSELECT KEY_BACK>;
+	};
+};
+
 &mpss_mem {
 	/* Firmware for rossa needs more space */
 	reg = <0x0 0x86800000 0x0 0x5800000>;

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-rossa.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-rossa.dts
@@ -40,3 +40,7 @@
 	/* Firmware for rossa needs more space */
 	reg = <0x0 0x86800000 0x0 0x5800000>;
 };
+
+&panel {
+	compatible = "samsung,cprime-panel";
+};


### PR DESCRIPTION
Discussion thread before upstreaming.

## Todo
- [x] Rename the device trees like downstream does (fortuna-*)
- [x] Or use the codenames in `build.prop`
- [ ] ~~Drop~~ Redo `samsung,fortuna`
- [ ] ~~Squash commits (Sensors, NFC...)~~
- [ ] Enable NFC for grandprimelte if there is anyone interested
- [ ] Add coreprimeltespr if there is anyone interested
- [ ] Add cprimeltetmo if there is anyone interested
- [ ] Add fortuna3gdtv if there is anyone interested. Cc @TotallyNotChloe 
- [ ] Add fortunaltedx if there is anyone interested. Cc @BaranSenkul
- [ ] Add fortunalteub if there is anyone interested. Cc @pachof

|Model|Current DTS|Codename|Downstream DTS|
|-----|-----------|--------|--------------|
|SM-G530BT|None|fortuna3gdtv|fortunadtv|
|SM-G530F|None|fortunaltedx|fortuna-sea|
|SM-G530FZ|[grandprimelte](https://github.com/torvalds/linux/blob/master/arch/arm64/boot/dts/qcom/msm8916-samsung-grandprimelte.dts)|grandprimelte|[fortuna-eur](https://github.com/msm8916-mainline/linux-downstream/blob/SM-G530FZ/arch/arm/boot/dts/samsung/msm8916/msm8916-sec-fortuna-eur-r02.dts)|
|SM-G530H|[fortuna3g](https://github.com/torvalds/linux/blob/master/arch/arm64/boot/dts/qcom/msm8216-samsung-fortuna3g.dts)|fortuna(ve)3g|[fortuna-r11](https://github.com/msm8916-mainline/linux-downstream/blob/SM-G530FZ/arch/arm/boot/dts/samsung/msm8916/msm8916-sec-fortuna-r11.dts)/[fortuna-ve3g](https://github.com/msm8916-mainline/linux-downstream/blob/SM-G530FZ/arch/arm/boot/dts/samsung/msm8916/msm8916-sec-fortuna-ve3g-r07.dts)|
|SM-G530M|None|fortunalteub|[fortuna-r11](https://github.com/msm8916-mainline/linux-downstream/blob/SM-G530FZ/arch/arm/boot/dts/samsung/msm8916/msm8916-sec-fortuna-r11.dts)|
|SM-G530MU/Y|None -> [fortunaltezt](https://github.com/msm8916-mainline/linux/blob/msm8916/6.6/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts)|fortunaltezt|[fortuna-r11](https://github.com/msm8916-mainline/linux-downstream/blob/SM-G530Y/arch/arm/boot/dts/samsung/msm8916-sec-fortuna-r11.dts) (another variant)|
|SM-G530W|[gprimeltecan](https://github.com/torvalds/linux/blob/master/arch/arm64/boot/dts/qcom/msm8916-samsung-gprimeltecan.dts)|gprimeltecan|[fortuna-tmo](https://github.com/msm8916-mainline/linux-downstream/blob/SM-G530W/arch/arm/boot/dts/samsung/msm8916/msm8916-sec-fortuna-tmo-r02.dts)|
|SM-G360G|[rossa](https://github.com/torvalds/linux/blob/master/arch/arm64/boot/dts/qcom/msm8916-samsung-rossa.dts)|rossaltexsa|[rossa-eur](https://github.com/msm8916-mainline/linux-downstream/blob/SM-G360G/arch/arm/boot/dts/samsung/msm8916/msm8916-sec-rossa-eur-r01.dts)|
|SM-G360P|None|coreprimeltespr|[rossaspr](https://github.com/msm8916-mainline/linux-downstream/blob/SM-G360P/arch/arm/boot/dts/samsung/msm8916/msm8916-sec-rossaspr-r03.dts)|
|SM-G360T|None|cprimeltetmo|[rossatmo](https://github.com/msm8916-mainline/linux-downstream/blob/SM-G530T/arch/arm/boot/dts/samsung/msm8916/msm8916-sec-rossatmo-r00.dts)|
|SM-G357FZ|None -> [heatqlte](https://github.com/msm8916-mainline/linux/blob/msm8916/6.6/arch/arm64/boot/dts/qcom/msm8916-samsung-heatqlte.dts)|heatqlte|[heat](https://github.com/msm8916-mainline/linux-downstream/blob/SM-G357FZ/arch/arm/boot/dts/samsung/msm8916-sec-heat-r02.dts)|

## Current conclusions
- Resort commits
- Apply new dt-schema
- Rename `gprime` into fortuna and `cprime` into `rossa` 
- Keep using codenames in `build.prop`
- Move `fortuna3g` to `msm8216`
- Add `grandprimelte`
- Replace gpio-vibrator with regulator-haptic
- Move `tz-apps@85a00000` to `msm8916-samsung-fortuna-common.dtsi`
- `interrupts-extended` will be used instead of `interrupt-parent` and `interrupts`, as preferred in upstream.
- The following will be upstreamed:
  - [x] `fortuna3g` Cc @SiddharthManthan 
  - [ ] ~~`fortunaltezt`~~ (postponed due to tsens issue)
  - [x] `grandprimelte`
  - [x] `gprimeltecan` Cc @buddyjojo @WTechNinja
  - [ ] ~~`heatqlte`~~ (postponed due to tsens issue) Cc @garethppls
  - [x] `rossa`
- To be upstreamed:
  - [x] Initial device trees, sound and modem
  https://lore.kernel.org/r/20240129143147.5058-1-raymondhackley@protonmail.com
  - [x] Fuel gauge
  https://lore.kernel.org/r/20240216124639.24689-1-raymondhackley@protonmail.com
  - [x] Touchscreen on fortuna
  https://lore.kernel.org/r/20240404121703.17086-2-raymondhackley@protonmail.com
  - [x] PWM backlight
  https://lore.kernel.org/r/20240404121703.17086-3-raymondhackley@protonmail.com
  - [x] Micro USB connector
  https://lore.kernel.org/r/20240424144922.28189-1-raymondhackley@protonmail.com
  - [x] Accelerometer / Magnetometer
  https://lore.kernel.org/r/20240405120803.20754-1-raymondhackley@protonmail.com
  - [x] NFC
  https://lore.kernel.org/r/20240601115321.25314-2-raymondhackley@protonmail.com
  https://lore.kernel.org/r/20240601115321.25314-3-raymondhackley@protonmail.com
  - [x] PMIC/Charger
  https://lore.kernel.org/r/20240601115321.25314-4-raymondhackley@protonmail.com
  - [x] Touchscreen on rossa
  https://lore.kernel.org/r/20240723131441.1764-1-raymondhackley@protonmail.com
  - [x] Zinitix touch keys on fortuna
  https://lore.kernel.org/r/20240724143230.3804-1-raymondhackley@protonmail.com