### PR TITLE
arm64: dts: qcom: msm8916-ufi: make UDC dual mode.

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-ufi.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-ufi.dtsi
@@ -109,7 +109,7 @@
 
 &usb {
 	extcon = <&pm8916_usbin>;
-	dr_mode = "peripheral";
+	usb-role-switch;
 
 	status = "okay";
 };


### PR DESCRIPTION
There are some requests for switching the UDC to host mode, but dr_mode="peripheral" prevents to do so. Remove dr_mode="peripheral" so that it defaults to otg mode and can be switched to host mode in userspace.

Not tested yet, though.