### PR TITLE
arm64: dts: qcom: msm8916-longcheer-l8910: Add flash LED

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-longcheer-l8910.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-longcheer-l8910.dts
@@ -97,6 +97,21 @@
 		pinctrl-0 = <&ts_vcca_default>;
 	};
 
+	flash-led-controller {
+		compatible = "ocs,ocp8110";
+		flash-gpios = <&msmgpio 119 GPIO_ACTIVE_HIGH>;
+		enable-gpios = <&msmgpio 49 GPIO_ACTIVE_HIGH>;
+
+		pinctrl-0 = <&camera_front_flash_default>;
+		pinctrl-names = "default";
+
+		flash_led: led {
+			function = LED_FUNCTION_FLASH;
+			color = <LED_COLOR_ID_WHITE>;
+			flash-max-timeout-us = <250000>;
+		};
+	};
+
 	usb_id: usb-id {
 		compatible = "linux,extcon-usb-gpio";
 		id-gpio = <&msmgpio 110 GPIO_ACTIVE_HIGH>;
@@ -433,6 +448,14 @@
 
 		drive-strength = <2>;
 		bias-disable;
+	};
+
+	camera_front_flash_default: camera-front-flash-default-state {
+		pins = "gpio49", "gpio119";
+		function = "gpio";
+
+		drive-strength = <2>;
+		bias-pull-down;
 	};
 
 	gpio_keys_default: gpio-keys-default-state {


### PR DESCRIPTION
l8910 uses OCP8110 flash LED driver. Add it to the device tree.

I couldn't test this, as I don't own the device.