### PR TITLE
dts: qcom: msm8916-mf601: initial support

### DIFF
--- a/Documentation/devicetree/bindings/arm/qcom.yaml
+++ b/Documentation/devicetree/bindings/arm/qcom.yaml
@@ -259,6 +259,7 @@ properties:
               - samsung,j5x
               - samsung,rossa
               - samsung,serranove
+              - thwc,mf601sl-ct-v07
               - thwc,uf896
               - thwc,ufi001c
               - wingtech,wt86518

--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -66,6 +66,7 @@ dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-j5x.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-rossa.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-on7.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-serranove.dtb
+dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-thwc-mf601sl-v7.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-thwc-uf896.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-thwc-ufi001c.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-vivo-y21l.dtb

--- a/arch/arm64/boot/dts/qcom/msm8916-thwc-mf601sl-v7.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-thwc-mf601sl-v7.dts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/* Also applies to MF601S_V2 */
+
+/dts-v1/;
+
+#include "msm8916-thwc-mf601xx.dtsi"
+
+/ {
+	model = "Tong Heng Wei Chuang 4G Modem Stick MF601SL_CT_V07";
+	compatible = "thwc,mf601sl-v7", "qcom,msm8916";
+};
+
+&led_mobile_g {
+	gpios = <&tlmm 116 GPIO_ACTIVE_HIGH>;
+};
+
+&led_mobile_r {
+	gpios = <&tlmm 115 GPIO_ACTIVE_HIGH>;
+};
+
+&led_bat_g {
+	gpios = <&tlmm 112 GPIO_ACTIVE_HIGH>;
+};
+
+&led_bat_r {
+	gpios = <&tlmm 110 GPIO_ACTIVE_HIGH>;
+};
+
+&led_mail_g {
+	gpios = <&tlmm 22 GPIO_ACTIVE_HIGH>;
+};
+
+&led_mail_r {
+	gpios = <&tlmm 121 GPIO_ACTIVE_HIGH>;
+};
+
+&led_wlan_g {
+	gpios = <&tlmm 120 GPIO_ACTIVE_HIGH>;
+};
+
+&led_wlan_r {
+	gpios = <&tlmm 119 GPIO_ACTIVE_HIGH>;
+};

--- a/arch/arm64/boot/dts/qcom/msm8916-thwc-mf601xx.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-thwc-mf601xx.dtsi
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// common dtsi for MF601xx series LTE modem MIFIs
+
+#include "msm8916-pm8916.dtsi"
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	chassis-type = "embedded";
+
+	aliases {
+		mmc0 = &sdhc_1; /* eMMC */
+		mmc1 = &sdhc_2; /* SD card */
+		serial0 = &blsp_uart2;
+	};
+
+	chosen {
+		stdout-path = "serial0";
+	};
+
+	/*
+	 * The battery is removable, so the values listed here are very conservative to ensure
+	 * charging safety. End-users should override them with matching values.
+	 */
+	battery: battery {
+		compatible = "simple-battery";
+		voltage-min-design-microvolt = <3400000>;
+		voltage-max-design-microvolt = <4200000>;
+		energy-full-design-microwatt-hours = <7770000>;
+		charge-full-design-microamp-hours = <2100000>;
+
+		ocv-capacity-celsius = <25>;
+		ocv-capacity-table-0 = <4189000 100>, <4073000 95>,
+			<4044000 90>, <4039000 85>, <4032000 80>, <4025000 75>,
+			<4008000 70>, <3974000 65>, <3953000 60>, <3912000 55>,
+			<3884000 50>, <3858000 45>, <3849000 40>, <3839000 35>,
+			<3816000 30>, <3774000 25>, <3690000 20>, <3647000 16>,
+			<3611000 13>, <3539000 11>, <3477000 10>, <3421000 9>,
+			<3388000 8>, <3364000 7>, <3328000 6>, <3235000 5>,
+			<3174000 4>, <3096000 3>, <3062000 2>, <3035000 1>,
+			<3000000 0>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		pinctrl-0 = <&button_default>;
+		pinctrl-names = "default";
+
+		label = "GPIO Buttons";
+
+		button-restart {
+			label = "Restart";
+			gpios = <&tlmm 34 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_RESTART>;
+		};
+
+		button-wps {
+			label = "WPS";
+			gpios = <&tlmm 107 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_WPS_BUTTON>;
+
+			/* This button is commonly unavailable */
+			status = "disabled";
+		};
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+
+		pinctrl-0 = <&gpio_leds_default>;
+		pinctrl-names = "default";
+
+		/* LEDs gpio are board-specific */
+		led_mobile_g: led-wan-green {
+			color = <LED_COLOR_ID_GREEN>;
+			default-state = "off";
+			function = LED_FUNCTION_MOBILE;
+		};
+
+		led_mobile_r: led-wan-red {
+			color = <LED_COLOR_ID_RED>;
+			default-state = "off";
+			function = LED_FUNCTION_MOBILE;
+		};
+
+		led_bat_g: led-battery-green {
+			color = <LED_COLOR_ID_GREEN>;
+			default-state = "on";
+			function = LED_FUNCTION_POWER;
+		};
+
+		led_bat_r: led-battery-red {
+			color = <LED_COLOR_ID_RED>;
+			default-state = "off";
+			function = LED_FUNCTION_POWER;
+		};
+
+		led_mail_g: led-mail-green {
+			color = <LED_COLOR_ID_GREEN>;
+			default-state = "off";
+			function = LED_FUNCTION_MAIL;
+		};
+
+		led_mail_r: led-mail-red {
+			color = <LED_COLOR_ID_RED>;
+			default-state = "off";
+			function = LED_FUNCTION_MAIL;
+		};
+
+		led_wlan_g: led-wlan-green {
+			color = <LED_COLOR_ID_GREEN>;
+			default-state = "off";
+			function = LED_FUNCTION_WLAN;
+		};
+
+		led_wlan_r: led-wlan-red {
+			color = <LED_COLOR_ID_RED>;
+			default-state = "off";
+			function = LED_FUNCTION_WLAN;
+		};
+	};
+
+	multi-led-mobile {
+		compatible = "leds-group-multicolor";
+		color = <LED_COLOR_ID_MULTI>;
+		function = LED_FUNCTION_MOBILE;
+		leds = <&led_mobile_g>, <&led_mobile_r>;
+	};
+
+	multi-led-battery {
+		compatible = "leds-group-multicolor";
+		color = <LED_COLOR_ID_MULTI>;
+		function = LED_FUNCTION_POWER;
+		leds = <&led_bat_g>, <&led_bat_r>;
+	};
+
+	multi-led-mail {
+		compatible = "leds-group-multicolor";
+		color = <LED_COLOR_ID_MULTI>;
+		function = LED_FUNCTION_MAIL;
+		leds = <&led_mail_g>, <&led_mail_r>;
+	};
+
+	multi-led-wlan {
+		compatible = "leds-group-multicolor";
+		color = <LED_COLOR_ID_MULTI>;
+		function = LED_FUNCTION_WLAN;
+		leds = <&led_wlan_g>, <&led_wlan_r>;
+	};
+};
+
+&bam_dmux {
+	status = "okay";
+};
+
+&bam_dmux_dma {
+	status = "okay";
+};
+
+&blsp_uart2 {
+	status = "okay";
+};
+
+/* Remove &dsi_phy0 from clocks to make sure that gcc probes with display disabled */
+&gcc {
+	clocks = <&xo_board>, <&sleep_clk>, <0>, <0>, <0>, <0>, <0>;
+};
+
+&mba_mem {
+	status = "okay";
+};
+
+&mpss {
+	pinctrl-0 = <&sim_ctrl_default>;
+	pinctrl-names = "default";
+
+	status = "okay";
+};
+
+&mpss_mem {
+	reg = <0x0 0x86800000 0x0 0x5500000>;
+	status = "okay";
+};
+
+&pm8916_bms {
+	monitored-battery = <&battery>;
+	power-supplies = <&pm8916_charger>;
+
+	status = "okay";
+};
+
+&pm8916_charger {
+	monitored-battery = <&battery>;
+
+	/* The values here are conservative and should be overrided in end-products */
+	qcom,fast-charge-safe-current = <500000>;
+	qcom,fast-charge-safe-voltage = <4200000>;
+
+	status = "okay";
+};
+
+&pm8916_rpm_regulators {
+	pm8916_l17: l17 {
+		regulator-min-microvolt = <2850000>;
+		regulator-max-microvolt = <2850000>;
+	};
+};
+
+&sdhc_1 {
+	status = "okay";
+};
+
+&sdhc_2 {
+	status = "okay";
+};
+
+&usb {
+	extcon = <&pm8916_charger>;
+	usb-role-switch;
+
+	status = "okay";
+};
+
+&usb_hs_phy {
+	extcon = <&pm8916_charger>;
+};
+
+&venus {
+	status = "okay";
+};
+
+&venus_mem {
+	status = "okay";
+};
+
+&wcnss {
+	status = "okay";
+};
+
+&wcnss_iris {
+	compatible = "qcom,wcn3620";
+};
+
+&wcnss_mem {
+	status = "okay";
+};
+
+&tlmm {
+	button_default: button-default-state {
+		function = "gpio";
+		drive-strength = <2>;
+		pins = "gpio34", "gpio107";
+		bias-pull-up;
+	};
+
+	gpio_leds_default: gpio-leds-default-state {
+		function = "gpio";
+		drive-strength = <2>;
+		pins = "gpio20", "gpio21", "gpio22", "gpio110", "gpio112",
+		       "gpio113", "gpio114", "gpio115", "gpio116", "gpio117",
+		       "gpio118", "gpio119", "gpio120", "gpio121";
+		bias-disable;
+	};
+
+	/* This selects the external SIM card slot by default */
+	sim_ctrl_default: sim-ctrl-default-state {
+		esim-sel-pins {
+			function = "gpio";
+			drive-strength = <2>;
+			pins = "gpio50", "gpio51";
+			bias-disable;
+			output-low;
+		};
+
+		sim-en-pins {
+			function = "gpio";
+			drive-strength = <2>;
+			pins = "gpio24";
+			bias-disable;
+			output-low;
+		};
+
+		sim-sel-pins {
+			function = "gpio";
+			drive-strength = <2>;
+			pins = "gpio49";
+			bias-disable;
+			output-high;
+		};
+	};
+};


### PR DESCRIPTION
Not fully tested yet. Only a draft.

TODO: How do we handle LEDs? Entirely in userspace or some with default-trigger? Do we need to follow the downstream usage of the LEDs?

Feedback is welcomed.

- [ ] random kernel oops, reason unknown

Tested peripherals:
- [x] USB OTG(needs external power supply)
- [ ] SDHC2(The slot is missing, but pads are there)
- [x] modem(only eSIM is tested)
- [x] WIFI
- [x] LEDs(okay)
- [x] button(except WPS)
- [x] bms/lbc