### PR TITLE
Charger smb1360: Increase timeout and current

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-alcatel-idol347.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-alcatel-idol347.dts
@@ -122,7 +122,7 @@
 
 		qcom,float-voltage-mv = <4350>;
 		qcom,iterm-ma = <75>;
-		qcom,charging-timeout = <192>; /* 0 in downstream */
+		qcom,charging-timeout = <768>; /* 0 in downstream */
 		qcom,recharge-thresh-mv = <100>;
 		qcom,chg-inhibit-disabled;
 

--- a/arch/arm64/boot/dts/qcom/msm8916-longcheer-l8910.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-longcheer-l8910.dts
@@ -166,7 +166,7 @@
 
 		qcom,float-voltage-mv = <4400>;
 		qcom,iterm-ma = <100>;
-		qcom,charging-timeout = <192>; /* 768 in downstream */
+		qcom,charging-timeout = <768>;
 		qcom,recharge-thresh-mv = <50>;
 		qcom,chg-inhibit-disabled;
 

--- a/arch/arm64/boot/dts/qcom/msm8916-wingtech-wt88047.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-wingtech-wt88047.dts
@@ -143,7 +143,7 @@
 
 		qcom,float-voltage-mv = <4350>;
 		qcom,iterm-ma = <100>;
-		qcom,charging-timeout = <192>; /* Not configured in downstream */
+		qcom,charging-timeout = <768>; /* Not configured in downstream */
 		qcom,chg-inhibit-disabled;
 
 		qcom,fg-batt-capacity-mah = <0>; /* Set by bootloader */

--- a/arch/arm64/boot/dts/qcom/msm8939-alcatel-idol3.dts
+++ b/arch/arm64/boot/dts/qcom/msm8939-alcatel-idol3.dts
@@ -199,7 +199,7 @@
 
 		qcom,float-voltage-mv = <4350>;
 		qcom,iterm-ma = <100>;
-		qcom,charging-timeout = <192>;
+		qcom,charging-timeout = <768>;
 		qcom,recharge-thresh-mv = <100>;
 		qcom,chg-inhibit-disabled;
 

--- a/arch/arm64/boot/dts/qcom/msm8939-longcheer-l9100.dts
+++ b/arch/arm64/boot/dts/qcom/msm8939-longcheer-l9100.dts
@@ -182,7 +182,7 @@
 
 		qcom,float-voltage-mv = <4400>;
 		qcom,iterm-ma = <100>;
-		qcom,charging-timeout = <192>; /* 768 in downstream */
+		qcom,charging-timeout = <768>;
 		qcom,recharge-thresh-mv = <50>;
 		qcom,chg-inhibit-disabled;
 


### PR DESCRIPTION
There has been an issue report [pmaports #1949](https://gitlab.com/postmarketOS/pmaports/-/issues/1949) that the charging of device bq-paella with charger smb1360 stops after 3 hours.

This PR disables the charging timeout in the devicetree of the devices using this charger. And additionally increases the charging current of the charger (hard-coded charging current as a temporary solution). More details can be found in the commit messages.

~~WIP: The changes are currently tested.~~