### PR TITLE
arm64: dts: qcom: msm8916-samsung-grandmax: Use sound model samsung-gmax

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-grandmax.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-grandmax.dts
@@ -122,6 +122,10 @@
 	status = "disabled";
 };
 
+&sound {
+	model = "samsung-gmax";
+};
+
 &msmgpio {
 	gpio_leds_default: gpio-led-default-state {
 		pins = "gpio60";


### PR DESCRIPTION
samsung-grandmax is too long so it's renamed into samsung-gmax here:

```
[   25.104571] qcom-apq8016-sbc 7702000.sound: ASoC: driver name too long 'samsung-grandmax' -> 'samsung-grandma'
```

- [x] msm8916-mainline/alsa-ucm-conf#13