### PR TITLE
arm64: dts: qcom: msm8916-samsung-gprime/j5: drop incorrect accelerometer interrupt-names

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
@@ -203,7 +203,6 @@
 		reg = <0x1d>;
 		interrupt-parent = <&tlmm>;
 		interrupts = <115 IRQ_TYPE_LEVEL_HIGH>;
-		interrupt-names = "INT1";
 
 		vdd-supply = <&pm8916_l17>;
 		vddio-supply = <&pm8916_l5>;

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-j5-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-j5-common.dtsi
@@ -105,7 +105,6 @@
 
 			interrupt-parent = <&tlmm>;
 			interrupts = <115 IRQ_TYPE_LEVEL_HIGH>;
-			interrupt-names = "INT1";
 
 			pinctrl-names = "default";
 			pinctrl-0 = <&accel_int_default>;


### PR DESCRIPTION
Preparing for e2015 upstreaming.
Link: https://lore.kernel.org/all/20230716190807.7056-1-linmengbo0689@protonmail.com/

Ref: c756d233715a899dd1cce4b1db4cbd50b0f55a9e
Link: https://lore.kernel.org/all/20230617171541.286957-1-krzysztof.kozlowski@linaro.org/