### PR TITLE
squash! arm64: dts: qcom: msm8939-huawei-kiwi: initial device tree

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8939-huawei-kiwi.dts
+++ b/arch/arm64/boot/dts/qcom/msm8939-huawei-kiwi.dts
@@ -8,7 +8,7 @@
 #include <dt-bindings/sound/apq8016-lpass.h>
 
 / {
-	model = "Huawei Honor 5X";
+	model = "Huawei Honor 5X / GR5 (2016)";
 	compatible = "huawei,kiwi", "qcom,msm8939";
 	chassis-type = "handset";
 


### PR DESCRIPTION
v2: Add GR5 (2016)