### PR TITLE
arm64: dts: qcom: msm8916/39-samsung-a2015/fortuna: Add PMIC and charger

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-a2015-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-a2015-common.dtsi
@@ -28,6 +28,12 @@
 		};
 	};
 
+	battery: battery {
+		compatible = "simple-battery";
+		precharge-current-microamp = <450000>;
+		precharge-upper-limit-microvolt = <3500000>;
+	};
+
 	clk_pwm: pwm {
 		compatible = "clk-pwm";
 		#pwm-cells = <2>;
@@ -128,6 +134,12 @@
 
 			pinctrl-names = "default";
 			pinctrl-0 = <&muic_int_default>;
+
+			usb_con: connector {
+				compatible = "usb-b-connector";
+				label = "micro-USB";
+				type = "micro";
+			};
 		};
 	};
 
@@ -239,7 +251,7 @@
 &blsp_i2c4 {
 	status = "okay";
 
-	battery@35 {
+	fuel-gauge@35 {
 		compatible = "richtek,rt5033-battery";
 		reg = <0x35>;
 		interrupt-parent = <&tlmm>;
@@ -247,6 +259,44 @@
 
 		pinctrl-names = "default";
 		pinctrl-0 = <&fg_alert_default>;
+
+		power-supplies = <&charger>;
+	};
+};
+
+&blsp_i2c6 {
+	status = "okay";
+
+	pmic@34 {
+		compatible = "richtek,rt5033";
+		reg = <0x34>;
+
+		interrupts-extended = <&tlmm 62 IRQ_TYPE_EDGE_FALLING>;
+
+		pinctrl-0 = <&pmic_int_default>;
+		pinctrl-names = "default";
+
+		regulators {
+			rt5033_reg_safe_ldo: SAFE_LDO {
+				regulator-min-microvolt = <4900000>;
+				regulator-max-microvolt = <4900000>;
+				regulator-always-on;
+			};
+
+			/*
+			 * Needed for camera, but not used yet.
+			 * Define empty nodes to allow disabling the unused
+			 * regulators.
+			 */
+			LDO {};
+			BUCK {};
+		};
+
+		charger: charger {
+			compatible = "richtek,rt5033-charger";
+			monitored-battery = <&battery>;
+			richtek,usb-connector = <&usb_con>;
+		};
 	};
 };
 
@@ -468,6 +518,13 @@
 		pins = "gpio0", "gpio1";
 		function = "gpio";
 
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	pmic_int_default: pmic-int-default-state {
+		pins = "gpio62";
+		function = "gpio";
 		drive-strength = <2>;
 		bias-disable;
 	};

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-a3u-eur.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-a3u-eur.dts
@@ -55,6 +55,12 @@
 		       "0", "0", "1";
 };
 
+&battery {
+	charge-term-current-microamp = <150000>;
+	constant-charge-current-max-microamp = <1000000>;
+	constant-charge-voltage-max-microvolt = <4350000>;
+};
+
 &blsp_i2c5 {
 	status = "okay";
 

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-a5u-eur.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-a5u-eur.dts
@@ -53,6 +53,12 @@
 			"0", "0", "1";
 };
 
+&battery {
+	charge-term-current-microamp = <200000>;
+	constant-charge-current-max-microamp = <1500000>;
+	constant-charge-voltage-max-microvolt = <4350000>;
+};
+
 &blsp_i2c5 {
 	status = "okay";
 

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-cprime-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-cprime-common.dtsi
@@ -25,6 +25,12 @@
 		interrupts = <12 IRQ_TYPE_EDGE_FALLING>;
 		pinctrl-0 = <&muic_int_default>;
 		pinctrl-names = "default";
+
+		usb_con: connector {
+			compatible = "usb-b-connector";
+			label = "micro-USB";
+			type = "micro";
+		};
 	};
 };
 

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-cprime.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-cprime.dts
@@ -10,6 +10,12 @@
 	chassis-type = "handset";
 };
 
+&battery {
+	charge-term-current-microamp = <150000>;
+	constant-charge-current-max-microamp = <700000>;
+	constant-charge-voltage-max-microvolt = <4400000>;
+};
+
 &blsp_i2c5 {
 	status = "okay";
 

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-e2015-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-e2015-common.dtsi
@@ -23,6 +23,12 @@
 
 			pinctrl-names = "default";
 			pinctrl-0 = <&muic_int_default>;
+
+			usb_con: connector {
+				compatible = "usb-b-connector";
+				label = "micro-USB";
+				type = "micro";
+			};
 		};
 	};
 

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-e5.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-e5.dts
@@ -23,6 +23,12 @@
 	chassis-type = "handset";
 };
 
+&battery {
+	charge-term-current-microamp = <200000>;
+	constant-charge-current-max-microamp = <1500000>;
+	constant-charge-voltage-max-microvolt = <4350000>;
+};
+
 &blsp_i2c5 {
 	status = "okay";
 

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-e7.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-e7.dts
@@ -60,6 +60,12 @@
 	};
 };
 
+&battery {
+	charge-term-current-microamp = <200000>;
+	constant-charge-current-max-microamp = <1500000>;
+	constant-charge-voltage-max-microvolt = <4350000>;
+};
+
 &blsp_i2c5 {
 	status = "okay";
 

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-fortuna3g.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-fortuna3g.dts
@@ -18,6 +18,12 @@
 	};
 };
 
+&battery {
+	charge-term-current-microamp = <200000>;
+	constant-charge-current-max-microamp = <1000000>;
+	constant-charge-voltage-max-microvolt = <4350000>;
+};
+
 &mpss_mem {
 	reg = <0x0 0x86800000 0x0 0x5000000>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-fortunaltezt.dts
@@ -30,6 +30,12 @@
 	};
 };
 
+&battery {
+	charge-term-current-microamp = <200000>;
+	constant-charge-current-max-microamp = <1000000>;
+	constant-charge-voltage-max-microvolt = <4350000>;
+};
+
 /* On fortunaltezt backlight is controlled with MIPI DCS commands */
 &clk_pwm {
 	status = "disabled";

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprime-common.dtsi
@@ -40,6 +40,12 @@
 		};
 	};
 
+	battery: battery {
+		compatible = "simple-battery";
+		precharge-current-microamp = <450000>;
+		precharge-upper-limit-microvolt = <3500000>;
+	};
+
 	clk_pwm_backlight: backlight {
 		compatible = "pwm-backlight";
 		pwms = <&clk_pwm 0 100000>;
@@ -158,6 +164,12 @@
 		interrupts = <12 IRQ_TYPE_EDGE_FALLING>;
 		pinctrl-0 = <&muic_int_default>;
 		pinctrl-names = "default";
+
+		usb_con: connector {
+			compatible = "usb-b-connector";
+			label = "micro-USB";
+			type = "micro";
+		};
 	};
 };
 
@@ -237,7 +249,7 @@
 &blsp_i2c4 {
 	status = "okay";
 
-	battery@35 {
+	fuel-gauge@35 {
 		compatible = "richtek,rt5033-battery";
 		reg = <0x35>;
 
@@ -246,6 +258,8 @@
 
 		pinctrl-0 = <&fg_alert_default>;
 		pinctrl-names = "default";
+
+		power-supplies = <&charger>;
 	};
 };
 
@@ -269,6 +283,42 @@
 		pinctrl-names = "default";
 
 		linux,keycodes = <KEY_APPSELECT KEY_BACK>;
+	};
+};
+
+&blsp_i2c6 {
+	status = "okay";
+
+	pmic@34 {
+		compatible = "richtek,rt5033";
+		reg = <0x34>;
+
+		interrupts-extended = <&tlmm 62 IRQ_TYPE_EDGE_FALLING>;
+
+		pinctrl-0 = <&pmic_int_default>;
+		pinctrl-names = "default";
+
+		regulators {
+			rt5033_reg_safe_ldo: SAFE_LDO {
+				regulator-min-microvolt = <4900000>;
+				regulator-max-microvolt = <4900000>;
+				regulator-always-on;
+			};
+
+			/*
+			 * Needed for camera, but not used yet.
+			 * Define empty nodes to allow disabling the unused
+			 * regulators.
+			 */
+			LDO {};
+			BUCK {};
+		};
+
+		charger: charger {
+			compatible = "richtek,rt5033-charger";
+			monitored-battery = <&battery>;
+			richtek,usb-connector = <&usb_con>;
+		};
 	};
 };
 
@@ -480,6 +530,13 @@
 
 	nfc_i2c_default: nfc-i2c-default-state {
 		pins = "gpio0", "gpio1";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	pmic_int_default: pmic-int-default-state {
+		pins = "gpio62";
 		function = "gpio";
 		drive-strength = <2>;
 		bias-disable;

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-gprimeltecan.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-gprimeltecan.dts
@@ -18,8 +18,17 @@
 	};
 };
 
+&battery {
+	charge-term-current-microamp = <200000>;
+	constant-charge-current-max-microamp = <1000000>;
+	constant-charge-voltage-max-microvolt = <4350000>;
+};
+
 &blsp_i2c6 {
 	status = "okay";
+
+	/* pmic@34 is on i2c_nfc instead */
+	/delete-node/ pmic@34;
 
 	nfc@27 {
 		compatible = "samsung,s3fwrn5-i2c";
@@ -44,6 +53,42 @@
 
 &bosch_magn {
 	status = "okay";
+};
+
+&i2c_nfc {
+	status = "okay";
+
+	pmic@34 {
+		compatible = "richtek,rt5033";
+		reg = <0x34>;
+
+		interrupts-extended = <&tlmm 62 IRQ_TYPE_EDGE_FALLING>;
+
+		pinctrl-0 = <&pmic_int_default>;
+		pinctrl-names = "default";
+
+		regulators {
+			rt5033_reg_safe_ldo: SAFE_LDO {
+				regulator-min-microvolt = <4900000>;
+				regulator-max-microvolt = <4900000>;
+				regulator-always-on;
+			};
+
+			/*
+			 * Needed for camera, but not used yet.
+			 * Define empty nodes to allow disabling the unused
+			 * regulators.
+			 */
+			LDO {};
+			BUCK {};
+		};
+
+		charger: charger {
+			compatible = "richtek,rt5033-charger";
+			monitored-battery = <&battery>;
+			richtek,usb-connector = <&usb_con>;
+		};
+	};
 };
 
 &mpss_mem {

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-grandmax.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-grandmax.dts
@@ -80,6 +80,12 @@
 	};
 };
 
+&battery {
+	charge-term-current-microamp = <150000>;
+	constant-charge-current-max-microamp = <1000000>;
+	constant-charge-voltage-max-microvolt = <4400000>;
+};
+
 &blsp_i2c5 {
 	status = "okay";
 

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-heatqlte.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-heatqlte.dts
@@ -22,6 +22,12 @@
 	chassis-type = "handset";
 };
 
+&battery {
+	charge-term-current-microamp = <150000>;
+	constant-charge-current-max-microamp = <700000>;
+	constant-charge-voltage-max-microvolt = <4350000>;
+};
+
 &mpss_mem {
 	reg = <0x0 0x86800000 0x0 0x5000000>;
 };

--- a/arch/arm64/boot/dts/qcom/msm8939-samsung-a7.dts
+++ b/arch/arm64/boot/dts/qcom/msm8939-samsung-a7.dts
@@ -33,6 +33,15 @@
 		};
 	};
 
+	battery: battery {
+		compatible = "simple-battery";
+		charge-term-current-microamp = <150000>;
+		constant-charge-current-max-microamp = <1500000>;
+		constant-charge-voltage-max-microvolt = <4300000>;
+		precharge-current-microamp = <450000>;
+		precharge-upper-limit-microvolt = <3500000>;
+	};
+
 	gpio-hall-sensor {
 		compatible = "gpio-keys";
 
@@ -82,7 +91,7 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 
-		battery@35 {
+		fuel-gauge@35 {
 			compatible = "richtek,rt5033-battery";
 			reg = <0x35>;
 
@@ -91,6 +100,8 @@
 
 			pinctrl-0 = <&fg_alert_default>;
 			pinctrl-names = "default";
+
+			power-supplies = <&charger>;
 		};
 	};
 
@@ -327,6 +338,12 @@
 
 		pinctrl-0 = <&muic_int_default>;
 		pinctrl-names = "default";
+
+		usb_con: connector {
+			compatible = "usb-b-connector";
+			label = "micro-USB";
+			type = "micro";
+		};
 	};
 };
 
@@ -357,6 +374,42 @@
 
 		pinctrl-0 = <&tsp_int_default>;
 		pinctrl-names = "default";
+	};
+};
+
+&blsp_i2c6 {
+	status = "okay";
+
+	pmic@34 {
+		compatible = "richtek,rt5033";
+		reg = <0x34>;
+
+		interrupts-extended = <&tlmm 62 IRQ_TYPE_EDGE_FALLING>;
+
+		pinctrl-0 = <&pmic_int_default>;
+		pinctrl-names = "default";
+
+		regulators {
+			rt5033_reg_safe_ldo: SAFE_LDO {
+				regulator-min-microvolt = <4900000>;
+				regulator-max-microvolt = <4900000>;
+				regulator-always-on;
+			};
+
+			/*
+			 * Needed for camera, but not used yet.
+			 * Define empty nodes to allow disabling the unused
+			 * regulators.
+			 */
+			LDO {};
+			BUCK {};
+		};
+
+		charger: charger {
+			compatible = "richtek,rt5033-charger";
+			monitored-battery = <&battery>;
+			richtek,usb-connector = <&usb_con>;
+		};
 	};
 };
 
@@ -618,6 +671,13 @@
 
 	nfc_i2c_default: nfc-i2c-default-state {
 		pins = "gpio0", "gpio1";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	pmic_int_default: pmic-int-default-state {
+		pins = "gpio62";
 		function = "gpio";
 		drive-strength = <2>;
 		bias-disable;


### PR DESCRIPTION
The phones listed below have Richteck RT5033 PMIC and charger.
Add them to the device trees.

- Samsung Galaxy A3/A5/A7 2015
- Samsung Galaxy E5/E7
- Samsung Galaxy Grand Max
- Samsung Galaxy Ace 4
- Samsung Galaxy Core Prime LTE
- Samsung Galaxy Grand Prime

Replaces #317 

Cc: @Jakko3