### PR TITLE
arm32 support for UFIs

### DIFF
--- a/arch/arm/boot/dts/qcom/Makefile
+++ b/arch/arm/boot/dts/qcom/Makefile
@@ -35,6 +35,9 @@ dtb-$(CONFIG_ARCH_QCOM) += \
 	qcom-msm8916-samsung-grandmax.dtb \
 	qcom-msm8916-samsung-heatqlte.dtb \
 	qcom-msm8916-samsung-serranove.dtb \
+	qcom-msm8916-thwc-uf896.dtb \
+	qcom-msm8916-thwc-ufi001c.dtb \
+	qcom-msm8916-yiming-uz801v3.dtb \
 	qcom-msm8960-cdp.dtb \
 	qcom-msm8960-samsung-expressatt.dtb \
 	qcom-msm8974-lge-nexus5-hammerhead.dtb \

--- a/arch/arm/boot/dts/qcom/qcom-msm8916-thwc-uf896.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8916-thwc-uf896.dts
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include "arm64/qcom/msm8916-thwc-uf896.dts"
+#include "qcom-msm8916-smp.dtsi"

--- a/arch/arm/boot/dts/qcom/qcom-msm8916-thwc-ufi001c.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8916-thwc-ufi001c.dts
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include "arm64/qcom/msm8916-thwc-ufi001c.dts"
+#include "qcom-msm8916-smp.dtsi"

--- a/arch/arm/boot/dts/qcom/qcom-msm8916-yiming-uz801v3.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8916-yiming-uz801v3.dts
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: GPL-2.0-only
+#include "arm64/qcom/msm8916-yiming-uz801v3.dts"
+#include "qcom-msm8916-smp.dtsi"


### PR DESCRIPTION
All of them already have arm64 support in mainline. But for the following reasons, it might be appropriate to add arm32 aupport:

1. arm64 is only supoorted with an updated tz. It's quite dangerous to flash tz, and it will break the downstream Android system.
2. arm64 consumes more RAM than arm32, which can not be ignored due to only 512 MiB of RAM (only ~320MiB available) for these devices.

So add arm32 support for them, even when arm64 is available.

Not tested yet.