### PR TITLE
arm64: dts: msm8916: add missing operating-points-v2 property to a53pll node

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916.dtsi
@@ -2569,6 +2569,7 @@
 			#clock-cells = <0>;
 			clocks = <&xo_board>;
 			clock-names = "xo";
+			operating-points-v2 = <&cpu_opp_table>;
 		};
 
 		timer@b020000 {


### PR DESCRIPTION
It makes over-clocking easier. otherwise, adding an unsupported freq would fail:
```kernel log
[   17.876015] cpu cpu0: dev_pm_opp_set_rate: failed to find OPP for freq 1600000000 (-34)
[   17.876036] cpufreq: __target_index: Failed to change cpu frequency: -34
```