### PR TITLE
arm64: dts: qcom: msm8939-longcheer-l9100: Add proximity-near-level

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8939-longcheer-l9100.dts
+++ b/arch/arm64/boot/dts/qcom/msm8939-longcheer-l9100.dts
@@ -181,6 +181,7 @@
 	light-sensor@23 {
 		compatible = "liteon,ltr559";
 		reg = <0x23>;
+		proximity-near-level = <75>;
 
 		vdd-supply = <&pm8916_l17>;
 		vddio-supply = <&pm8916_l5>;


### PR DESCRIPTION
Consider an object near to the sensor when their distance is about 4 cm or below.

Reviewed-by: Konrad Dybcio <konrad.dybcio@linaro.org>
Link: https://lore.kernel.org/r/20231016-bqm5_prox-v1-1-2acdc732be9d@apitzsch.eu