### PR TITLE
arm64: dts: qcom: msm8916-samsung-e5: Correct accelerometer matrix

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-e2015-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-e2015-common.dtsi
@@ -62,8 +62,8 @@
 		vddio-supply = <&pm8916_l5>;
 
 		st,drdy-int-pin = <1>;
-		mount-matrix = "1", "0", "0",
-			       "0", "-1", "0",
+		mount-matrix = "-1", "0", "0",
+			       "0", "1", "0",
 			       "0", "0", "1";
 
 		pinctrl-0 = <&accel_int_default>;

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-e2015-common.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-e2015-common.dtsi
@@ -51,7 +51,7 @@
 	/delete-node/ accelerometer@10;
 	/delete-node/ magnetometer@12;
 
-	accelerometer@1d {
+	accelerometer: accelerometer@1d {
 		compatible = "st,lis2hh12";
 		reg = <0x1d>;
 
@@ -62,8 +62,8 @@
 		vddio-supply = <&pm8916_l5>;
 
 		st,drdy-int-pin = <1>;
-		mount-matrix = "-1", "0", "0",
-			       "0", "1", "0",
+		mount-matrix = "1", "0", "0",
+			       "0", "-1", "0",
 			       "0", "0", "1";
 
 		pinctrl-0 = <&accel_int_default>;

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-e5.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-e5.dts
@@ -29,6 +29,12 @@
 	constant-charge-voltage-max-microvolt = <4350000>;
 };
 
+&accelerometer {
+	mount-matrix = "-1", "0", "0",
+			"0", "1", "0",
+			"0", "0", "1";
+};
+
 &blsp_i2c5 {
 	status = "okay";
 


### PR DESCRIPTION
Update the accelerometer matrix to report the,
correct values instead of flipped ones.