### PR TITLE
squash! arm64: dts: qcom: msm8916-samsung-a5u: Add display panel (v2)

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-a5u-eur.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-a5u-eur.dts
@@ -12,6 +12,7 @@
 	reg_vlcd_vdd3: regulator-vlcd-vdd3 {
 		compatible = "regulator-fixed";
 		regulator-name = "vlcd_vdd3";
+		regulator-boot-on;
 		regulator-min-microvolt = <1800000>;
 		regulator-max-microvolt = <1800000>;
 		vin-supply = <&pm8916_s4>;
@@ -26,6 +27,7 @@
 	reg_vlcd_vci: regulator-vlcd-vci {
 		compatible = "regulator-fixed";
 		regulator-name = "vlcd_vci";
+		regulator-boot-on;
 		regulator-min-microvolt = <3000000>;
 		regulator-max-microvolt = <3000000>;
 


### PR DESCRIPTION
[Sam: Add regulator-boot-on to preserve display in u-boot]