### PR TITLE
arm64: dts: qcom: msm8916-samsung-heatqlte: Add touchkeys

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-heatqlte.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-heatqlte.dts
@@ -20,6 +20,59 @@
 	model = "Samsung Galaxy Ace 4 (SM-G357FZ)";
 	compatible = "samsung,heatqlte", "qcom,msm8916";
 	chassis-type = "handset";
+
+	i2c-touchkey {
+		compatible = "i2c-gpio";
+		sda-gpios = <&tlmm 8 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+		scl-gpios = <&tlmm 10 (GPIO_ACTIVE_HIGH|GPIO_OPEN_DRAIN)>;
+
+		pinctrl-0 = <&touchkey_i2c_default>;
+		pinctrl-names = "default";
+
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		touchkey@20 {
+			compatible = "cypress,tm2-touchkey";
+			reg = <0x20>;
+
+			interrupts-extended = <&tlmm 9 IRQ_TYPE_EDGE_RISING>;
+
+			vcc-supply = <&reg_vcc_touchkey>;
+			vdd-supply = <&reg_vdd_touchkey_led>;
+
+			pinctrl-0 = <&touchkey_int_default>;
+			pinctrl-names = "default";
+
+			linux,keycodes = <KEY_APPSELECT KEY_BACK>;
+		};
+	};
+
+	reg_vcc_touchkey: regulator-vcc-touchkey {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_touchkey";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+
+		gpio = <&tlmm 11 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+
+		pinctrl-0 = <&vdd_touchkey_default>;
+		pinctrl-names = "default";
+	};
+
+	reg_vdd_touchkey_led: regulator-vdd-touchkey-led {
+		compatible = "regulator-fixed";
+		regulator-name = "vdd_touchkey_led";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+
+		gpio = <&tlmm 60 GPIO_ACTIVE_HIGH>;
+		enable-active-high;
+
+		pinctrl-0 = <&vdd_touchkey_led_default>;
+		pinctrl-names = "default";
+	};
 };
 
 &battery {
@@ -34,4 +87,34 @@
 
 &panel {
 	compatible = "samsung,s6288a0";
+};
+
+&tlmm {
+	touchkey_i2c_default: touchkey-i2c-default-state {
+		pins = "gpio8", "gpio10";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	touchkey_int_default: touchkey-int-default-state {
+		pins = "gpio9";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	vdd_touchkey_default: vdd-touchkey-default-state {
+		pins = "gpio11";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	vdd_touchkey_led_default: vdd-touchkey-led-default-state {
+		pins = "gpio60";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
 };


### PR DESCRIPTION
Hi! This is my first time contributing to kernel-adjacent projects so please teach me the ways as you find necessary, I'm all up for learning.

This devicetree patch enables the Cypress tm2-touchkey device controlling the menu and back keys in the Samsung heatqlte (SM-G357FZ) and their backlight leds

Since GPIOs 8 and 10 have no hardware I2C interface software emulation is used via i2c-gpio, just like in the downstream kernel

I've set up the pinctrl as well, however I'm yet to learn more about this subsystem. Please point out anything I may have done wrong

Thanks!