### PR TITLE
q6voice Makefile target de-duplication

### DIFF
--- a/sound/soc/qcom/qdsp6/Makefile
+++ b/sound/soc/qcom/qdsp6/Makefile
@@ -11,7 +11,6 @@ obj-$(CONFIG_SND_SOC_QDSP6_ADM) += q6adm.o
 obj-$(CONFIG_SND_SOC_QDSP6_ROUTING) += q6routing.o
 obj-$(CONFIG_SND_SOC_QDSP6_ASM) += q6asm.o
 obj-$(CONFIG_SND_SOC_QDSP6_ASM_DAI) += q6asm-dai.o
-obj-$(CONFIG_SND_SOC_QDSP6_Q6VOICE) += q6cvp.o q6mvm.o q6voice-common.o
 obj-$(CONFIG_SND_SOC_QDSP6_Q6VOICE) += q6cvp.o q6cvs.o q6mvm.o q6voice-common.o
 obj-$(CONFIG_SND_SOC_QDSP6_Q6VOICE) += q6voice.o
 obj-$(CONFIG_SND_SOC_QDSP6_Q6VOICE_DAI) += q6voice-dai.o

--- a/sound/soc/qcom/qdsp6/Makefile
+++ b/sound/soc/qcom/qdsp6/Makefile
@@ -11,7 +11,6 @@ obj-$(CONFIG_SND_SOC_QDSP6_ADM) += q6adm.o
 obj-$(CONFIG_SND_SOC_QDSP6_ROUTING) += q6routing.o
 obj-$(CONFIG_SND_SOC_QDSP6_ASM) += q6asm.o
 obj-$(CONFIG_SND_SOC_QDSP6_ASM_DAI) += q6asm-dai.o
-obj-$(CONFIG_SND_SOC_QDSP6_Q6VOICE) += q6mvm.o q6voice-common.o
 obj-$(CONFIG_SND_SOC_QDSP6_Q6VOICE) += q6cvp.o q6mvm.o q6voice-common.o
 obj-$(CONFIG_SND_SOC_QDSP6_Q6VOICE) += q6cvp.o q6cvs.o q6mvm.o q6voice-common.o
 obj-$(CONFIG_SND_SOC_QDSP6_Q6VOICE) += q6voice.o

--- a/sound/soc/qcom/qdsp6/Makefile
+++ b/sound/soc/qcom/qdsp6/Makefile
@@ -11,7 +11,6 @@ obj-$(CONFIG_SND_SOC_QDSP6_ADM) += q6adm.o
 obj-$(CONFIG_SND_SOC_QDSP6_ROUTING) += q6routing.o
 obj-$(CONFIG_SND_SOC_QDSP6_ASM) += q6asm.o
 obj-$(CONFIG_SND_SOC_QDSP6_ASM_DAI) += q6asm-dai.o
-obj-$(CONFIG_SND_SOC_QDSP6_Q6VOICE) += q6voice-common.o
 obj-$(CONFIG_SND_SOC_QDSP6_Q6VOICE) += q6mvm.o q6voice-common.o
 obj-$(CONFIG_SND_SOC_QDSP6_Q6VOICE) += q6cvp.o q6mvm.o q6voice-common.o
 obj-$(CONFIG_SND_SOC_QDSP6_Q6VOICE) += q6cvp.o q6cvs.o q6mvm.o q6voice-common.o


### PR DESCRIPTION
This cleans up the q6voice patches to bring them closer to how the merge conflicts were resolved for sdm845-5.17.0.

For signoffs, the most recent fixups didn't include them. For authorship, I can't really trace who from SDM845 resolved the conflicts like this without taking a closer look.

CC: @joelselvaraj @calebccff