### PR TITLE
arm64: dts: qcom: msm8916: Pull-up the UART RX pin

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8916.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8916.dtsi
@@ -1279,10 +1279,20 @@
 			};
 
 			blsp_uart2_default: blsp-uart2-default-state {
-				pins = "gpio4", "gpio5";
-				function = "blsp_uart2";
-				drive-strength = <16>;
-				bias-disable;
+				tx-pins {
+					pins = "gpio4";
+					function = "blsp_uart2";
+					drive-strength = <16>;
+					bias-disable;
+				};
+				rx-pins {
+					pins = "gpio5";
+					function = "blsp_uart2";
+					drive-strength = <16>;
+					bias-pull-up;
+					bootph-all;
+				};
+
 			};
 
 			blsp_uart2_sleep: blsp-uart2-sleep-state {


### PR DESCRIPTION
With UART disconnected, no one is driving the UART RX line. It will be floating, which can end up producing garbage on stdin.

Reliable UART is particularly important in early boot stages, otherwise an autoboot sequence might be interrupted, so bootph-all is also added to the RX pin.
