### PR TITLE
ARM: dts: qcom: msm8909-lenovo-lxf-p5100: Add fuel gauge

### DIFF
--- a/arch/arm/boot/dts/qcom/qcom-msm8909-lenovo-lxf-p5100.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8909-lenovo-lxf-p5100.dts
@@ -175,13 +175,17 @@
 	};
 };
 
-&blsp_uart1 {
+&blsp_i2c6 {
 	status = "okay";
+
+	fuel-gauge@55 {
+		monitored-battery = <&battery>;
+		compatible = "ti,bq27500";
+		reg = <0x55>;
+	};
 };
 
-/* FIXME: Missing the real fuel gauge's node */
-&pm8909_bms {
-	monitored-battery = <&battery>;
+&blsp_uart1 {
 	status = "okay";
 };
 


### PR DESCRIPTION
```
acer-t01:~/linux$ cat /sys/class/power_supply/bq27500-0/capacity
20
``` 
I don't know what chip is used in the battery thus i modeled it as bq27000.

I have compared the capacity reading to downstream and it seem been same as the downstream hence it work.