### PR TITLE
squash! ARM: dts: qcom: msm8909-acer-t01: Add simple-framebuffer

### DIFF
--- a/arch/arm/boot/dts/qcom/qcom-msm8909-acer-t01.dts
+++ b/arch/arm/boot/dts/qcom/qcom-msm8909-acer-t01.dts
@@ -20,11 +20,15 @@
 	};
 
 	chosen {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
 		stdout-path = "serial0";
 
-		framebuffer@83200000 {
+		framebuffer@83201000 {
 			compatible = "simple-framebuffer";
-			reg = <0x83200000 (480 * 854 * 3)>;
+			reg = <0x83201000 (480 * 854 * 3)>;
 
 			width = <480>;
 			height = <854>;
@@ -40,6 +44,17 @@
 				 <&gcc GCC_MDSS_BYTE0_CLK>,
 				 <&gcc GCC_MDSS_PCLK0_CLK>,
 				 <&gcc GCC_MDSS_ESC0_CLK>;
+		};
+	};
+
+	reserved-memory {
+		#address-cells = <1>;
+		#size-cells = <1>;
+		ranges;
+
+		framebuffer@83201000 {
+			reg = <0x83201000 (480 * 854 * 3)>;
+			no-map;
 		};
 	};
 


### PR DESCRIPTION
v2:
Fix address:
[    0.838347] simple-framebuffer chosen:framebuffer@83200000: probe with driver simple-framebuffer failed with error -22

Fix compiler warnings:
Warning (reg_format): /chosen/framebuffer@83201000:reg: property has invalid length (8 bytes) (#address-cells == 2, #size-cells == 1)

Fix memory region:
[    0.838348] simple-framebuffer 83201000.framebuffer: [drm] could not acquire memory region [mem 0x83201000-0x8332d3bf flags 0x200]