### PR TITLE
arm64: dts: qcom: msm8916-samsung-coreprimeltevzw: add device tree

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -48,6 +48,7 @@ dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-mtp.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-a3u-eur.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-a5-zt.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-a5u-eur.dtb
+dtb-$(CONFIG_ARCH_QCOM) += msm8916-samsung-coreprimeltevzw.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-e5.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-e7.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-fortunaltezt.dtb

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-coreprimeltevzw.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-coreprimeltevzw.dts
@@ -60,6 +60,10 @@
 	reg = <0x0 0x86800000 0x0 0x5800000>;
 };
 
+&panel {
+	compatible = "samsung,cprime-panel";
+};
+
 &s3fwrn5_nfc {
 	status = "disabled";
 };

--- a/arch/arm64/boot/dts/qcom/msm8916-samsung-coreprimeltevzw.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-samsung-coreprimeltevzw.dts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include "msm8916-samsung-rossa-common.dtsi"
+
+/* SM5502 MUIC instead of SM5504 */
+/delete-node/ &muic;
+
+/ {
+	model = "Samsung Galaxy Core Prime LTE Verizon Wireless";
+	compatible = "samsung,coreprimeltevzw", "qcom,msm8916";
+	chassis-type = "handset";
+};
+
+&battery {
+	charge-term-current-microamp = <150000>;
+	constant-charge-current-max-microamp = <700000>;
+	constant-charge-voltage-max-microvolt = <4400000>;
+};
+
+&blsp_i2c1 {
+	muic: extcon@25 {
+		compatible = "siliconmitus,sm5502-muic";
+		reg = <0x25>;
+		interrupts-extended = <&tlmm 12 IRQ_TYPE_EDGE_FALLING>;
+		pinctrl-0 = <&muic_int_default>;
+		pinctrl-names = "default";
+
+		usb_con: connector {
+			compatible = "usb-b-connector";
+			label = "micro-USB";
+			type = "micro";
+		};
+	};
+};
+
+&blsp_i2c5 {
+	touchscreen@50 {
+		compatible = "imagis,ist3038";
+		reg = <0x50>;
+
+		interrupts-extended = <&tlmm 13 IRQ_TYPE_EDGE_FALLING>;
+
+		touchscreen-size-x = <480>;
+		touchscreen-size-y = <800>;
+
+		vdd-supply = <&reg_vdd_tsp_a>;
+		vddio-supply = <&pm8916_l6>;
+
+		pinctrl-0 = <&tsp_int_default>;
+		pinctrl-names = "default";
+
+		linux,keycodes = <KEY_APPSELECT KEY_BACK>;
+	};
+};
+
+&mpss_mem {
+	/* Firmware for rossa needs more space */
+	reg = <0x0 0x86800000 0x0 0x5800000>;
+};
+
+&s3fwrn5_nfc {
+	status = "disabled";
+};


### PR DESCRIPTION
This adds a device tree for the SM-G360V/SM-G360R6 variants of the Samsung Galaxy Core Prime. Issues:
* Sound does not work under the `no-modem` rpoc mode, and `[   26.466333] platform 7702000.sound: deferred probe pending: qcom-apq8016-sbc: MultiMedia1: error getting cpu dai name` gets printed to dmesg.
* NFC does not work on my SM-G360V, however I did not find settings for it in Android, so that may be normal. The controller in the device tree is the one I found in the stock device tree.