### PR TITLE
HACK: arm64: dts: qcom: msm8939: Remove assigned-clocks for now

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8939.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8939.dtsi
@@ -2188,8 +2188,6 @@
 			clocks = <&a53pll_c1>, <&gcc GPLL0_VOTE>, <&rpmcc RPM_SMD_XO_CLK_SRC>;
 			clock-names = "pll", "aux", "ref";
 			#clock-cells = <0>;
-			assigned-clocks = <&apcs2>;
-			assigned-clock-rates = <297600000>;
 			#mbox-cells = <1>;
 		};
 


### PR DESCRIPTION
'assigned-clocks' causes issues with bringing up the modem.