### PR TITLE
Backport privilege escalation security fix for CVE-2025-39698 from linux 6.12.44

### DIFF
--- a/io_uring/futex.c
+++ b/io_uring/futex.c
@@ -337,6 +337,7 @@ int io_futex_wait(struct io_kiocb *req, unsigned int issue_flags)
 		goto done_unlock;
 	}
 
+	req->flags |= REQ_F_ASYNC_DATA;
 	req->async_data = ifd;
 	ifd->q = futex_q_init;
 	ifd->q.bitset = iof->futex_mask;
@@ -359,6 +360,8 @@ done:
 	if (ret < 0)
 		req_set_fail(req);
 	io_req_set_res(req, ret, 0);
+	req->async_data = NULL;
+	req->flags &= ~REQ_F_ASYNC_DATA;
 	kfree(ifd);
 	return IOU_OK;
 }


### PR DESCRIPTION
[CVE link](https://www.cve.org/CVERecord?id=CVE-2025-39698)
Linux upstream commits:
d9f93172820a53ab42c4b0e5e65291f4f9d00ad2
d34c04152df517c59979b4bf2a47f491e06d3256
508c1314b342b78591f51c4b5dadee31a88335df
[CVE announce](https://lore.kernel.org/linux-cve-announce/2025090548-CVE-2025-39698-41e0@gregkh/T/#u)

This pr tested on pmbootstrap compiling, and wileyfox swift booting up