### PR TITLE
HACK: remoteproc: qcom: Revert "remoteproc: qcom: Use of_reserved_mem_region_* functions for "memory-region"" and related commits

### DIFF
--- a/drivers/remoteproc/qcom_q6v5_adsp.c
+++ b/drivers/remoteproc/qcom_q6v5_adsp.c
@@ -637,10 +637,9 @@ static int adsp_alloc_memory_region(struct qcom_adsp *adsp)
 	adsp->mem_phys = adsp->mem_reloc = res.start;
 	adsp->mem_size = resource_size(&res);
 	adsp->mem_region = devm_ioremap_resource_wc(adsp->dev, &res);
-	if (IS_ERR(adsp->mem_region)) {
+	if (!adsp->mem_region) {
 		dev_err(adsp->dev, "unable to map memory region: %pR\n", &res);
-		return PTR_ERR(adsp->mem_region);
-
+		return -EBUSY;
 	}
 
 	return 0;

--- a/drivers/remoteproc/qcom_q6v5_adsp.c
+++ b/drivers/remoteproc/qcom_q6v5_adsp.c
@@ -625,20 +625,26 @@ static int adsp_init_mmio(struct qcom_adsp *adsp,
 
 static int adsp_alloc_memory_region(struct qcom_adsp *adsp)
 {
-	int ret;
-	struct resource res;
+	struct reserved_mem *rmem = NULL;
+	struct device_node *node;
 
-	ret = of_reserved_mem_region_to_resource(adsp->dev->of_node, 0, &res);
-	if (ret) {
+	node = of_parse_phandle(adsp->dev->of_node, "memory-region", 0);
+	if (node)
+		rmem = of_reserved_mem_lookup(node);
+	of_node_put(node);
+
+	if (!rmem) {
 		dev_err(adsp->dev, "unable to resolve memory-region\n");
-		return ret;
+		return -EINVAL;
 	}
 
-	adsp->mem_phys = adsp->mem_reloc = res.start;
-	adsp->mem_size = resource_size(&res);
-	adsp->mem_region = devm_ioremap_resource_wc(adsp->dev, &res);
+	adsp->mem_phys = adsp->mem_reloc = rmem->base;
+	adsp->mem_size = rmem->size;
+	adsp->mem_region = devm_ioremap_wc(adsp->dev,
+				adsp->mem_phys, adsp->mem_size);
 	if (!adsp->mem_region) {
-		dev_err(adsp->dev, "unable to map memory region: %pR\n", &res);
+		dev_err(adsp->dev, "unable to map memory region: %pa+%zx\n",
+			&rmem->base, adsp->mem_size);
 		return -EBUSY;
 	}
 

--- a/drivers/remoteproc/qcom_q6v5_mss.c
+++ b/drivers/remoteproc/qcom_q6v5_mss.c
@@ -1970,8 +1970,8 @@ static int q6v5_init_reset(struct q6v5 *qproc)
 static int q6v5_alloc_memory_region(struct q6v5 *qproc)
 {
 	struct device_node *child;
-	struct resource res;
-	int ret;
+	struct reserved_mem *rmem;
+	struct device_node *node;
 
 	/*
 	 * In the absence of mba/mpss sub-child, extract the mba and mpss
@@ -1979,49 +1979,71 @@ static int q6v5_alloc_memory_region(struct q6v5 *qproc)
 	 */
 	child = of_get_child_by_name(qproc->dev->of_node, "mba");
 	if (!child) {
-		ret = of_reserved_mem_region_to_resource(qproc->dev->of_node, 0, &res);
+		node = of_parse_phandle(qproc->dev->of_node,
+					"memory-region", 0);
 	} else {
-		ret = of_reserved_mem_region_to_resource(child, 0, &res);
+		node = of_parse_phandle(child, "memory-region", 0);
 		of_node_put(child);
 	}
 
-	if (ret) {
-		dev_err(qproc->dev, "unable to resolve mba region\n");
-		return ret;
+	if (!node) {
+		dev_err(qproc->dev, "no mba memory-region specified\n");
+		return -EINVAL;
 	}
 
-	qproc->mba_phys = res.start;
-	qproc->mba_size = resource_size(&res);
+	rmem = of_reserved_mem_lookup(node);
+	of_node_put(node);
+	if (!rmem) {
+		dev_err(qproc->dev, "unable to resolve mba region\n");
+		return -EINVAL;
+	}
+
+	qproc->mba_phys = rmem->base;
+	qproc->mba_size = rmem->size;
 
 	if (!child) {
-		ret = of_reserved_mem_region_to_resource(qproc->dev->of_node, 1, &res);
+		node = of_parse_phandle(qproc->dev->of_node,
+					"memory-region", 1);
 	} else {
 		child = of_get_child_by_name(qproc->dev->of_node, "mpss");
-		ret = of_reserved_mem_region_to_resource(child, 0, &res);
+		node = of_parse_phandle(child, "memory-region", 0);
 		of_node_put(child);
 	}
 
-	if (ret) {
-		dev_err(qproc->dev, "unable to resolve mpss region\n");
-		return ret;
+	if (!node) {
+		dev_err(qproc->dev, "no mpss memory-region specified\n");
+		return -EINVAL;
 	}
 
-	qproc->mpss_phys = qproc->mpss_reloc = res.start;
-	qproc->mpss_size = resource_size(&res);
+	rmem = of_reserved_mem_lookup(node);
+	of_node_put(node);
+	if (!rmem) {
+		dev_err(qproc->dev, "unable to resolve mpss region\n");
+		return -EINVAL;
+	}
+
+	qproc->mpss_phys = qproc->mpss_reloc = rmem->base;
+	qproc->mpss_size = rmem->size;
 
 	if (!child) {
-		ret = of_reserved_mem_region_to_resource(qproc->dev->of_node, 2, &res);
+		node = of_parse_phandle(qproc->dev->of_node, "memory-region", 2);
 	} else {
 		child = of_get_child_by_name(qproc->dev->of_node, "metadata");
-		ret = of_reserved_mem_region_to_resource(child, 0, &res);
+		node = of_parse_phandle(child, "memory-region", 0);
 		of_node_put(child);
 	}
 
-	if (ret)
+	if (!node)
 		return 0;
 
-	qproc->mdata_phys = res.start;
-	qproc->mdata_size = resource_size(&res);
+	rmem = of_reserved_mem_lookup(node);
+	if (!rmem) {
+		dev_err(qproc->dev, "unable to resolve metadata region\n");
+		return -EINVAL;
+	}
+
+	qproc->mdata_phys = rmem->base;
+	qproc->mdata_size = rmem->size;
 
 	return 0;
 }

--- a/drivers/remoteproc/qcom_q6v5_pas.c
+++ b/drivers/remoteproc/qcom_q6v5_pas.c
@@ -559,9 +559,9 @@ static int qcom_pas_alloc_memory_region(struct qcom_pas *pas)
 	pas->mem_phys = pas->mem_reloc = res.start;
 	pas->mem_size = resource_size(&res);
 	pas->mem_region = devm_ioremap_resource_wc(pas->dev, &res);
-	if (IS_ERR(pas->mem_region)) {
+	if (!pas->mem_region) {
 		dev_err(pas->dev, "unable to map memory region: %pR\n", &res);
-		return PTR_ERR(pas->mem_region);
+		return -EBUSY;
 	}
 
 	if (!pas->dtb_pas_id)
@@ -576,9 +576,9 @@ static int qcom_pas_alloc_memory_region(struct qcom_pas *pas)
 	pas->dtb_mem_phys = pas->dtb_mem_reloc = res.start;
 	pas->dtb_mem_size = resource_size(&res);
 	pas->dtb_mem_region = devm_ioremap_resource_wc(pas->dev, &res);
-	if (IS_ERR(pas->dtb_mem_region)) {
+	if (!pas->dtb_mem_region) {
 		dev_err(pas->dev, "unable to map dtb memory region: %pR\n", &res);
-		return PTR_ERR(pas->dtb_mem_region);
+		return -EBUSY;
 	}
 
 	return 0;

--- a/drivers/remoteproc/qcom_q6v5_pas.c
+++ b/drivers/remoteproc/qcom_q6v5_pas.c
@@ -547,37 +547,53 @@ static void qcom_pas_pds_detach(struct qcom_pas *pas, struct device **pds, size_
 
 static int qcom_pas_alloc_memory_region(struct qcom_pas *pas)
 {
-	struct resource res;
-	int ret;
+	struct reserved_mem *rmem;
+	struct device_node *node;
 
-	ret = of_reserved_mem_region_to_resource(pas->dev->of_node, 0, &res);
-	if (ret) {
-		dev_err(pas->dev, "unable to resolve memory-region\n");
-		return ret;
+	node = of_parse_phandle(pas->dev->of_node, "memory-region", 0);
+	if (!node) {
+		dev_err(pas->dev, "no memory-region specified\n");
+		return -EINVAL;
 	}
 
-	pas->mem_phys = pas->mem_reloc = res.start;
-	pas->mem_size = resource_size(&res);
-	pas->mem_region = devm_ioremap_resource_wc(pas->dev, &res);
+	rmem = of_reserved_mem_lookup(node);
+	of_node_put(node);
+	if (!rmem) {
+		dev_err(pas->dev, "unable to resolve memory-region\n");
+		return -EINVAL;
+	}
+
+	pas->mem_phys = pas->mem_reloc = rmem->base;
+	pas->mem_size = rmem->size;
+	pas->mem_region = devm_ioremap_wc(pas->dev, pas->mem_phys, pas->mem_size);
 	if (!pas->mem_region) {
-		dev_err(pas->dev, "unable to map memory region: %pR\n", &res);
+		dev_err(pas->dev, "unable to map memory region: %pa+%zx\n",
+			&rmem->base, pas->mem_size);
 		return -EBUSY;
 	}
 
 	if (!pas->dtb_pas_id)
 		return 0;
 
-	ret = of_reserved_mem_region_to_resource(pas->dev->of_node, 1, &res);
-	if (ret) {
-		dev_err(pas->dev, "unable to resolve dtb memory-region\n");
-		return ret;
+	node = of_parse_phandle(pas->dev->of_node, "memory-region", 1);
+	if (!node) {
+		dev_err(pas->dev, "no dtb memory-region specified\n");
+		return -EINVAL;
 	}
 
-	pas->dtb_mem_phys = pas->dtb_mem_reloc = res.start;
-	pas->dtb_mem_size = resource_size(&res);
-	pas->dtb_mem_region = devm_ioremap_resource_wc(pas->dev, &res);
+	rmem = of_reserved_mem_lookup(node);
+	of_node_put(node);
+	if (!rmem) {
+		dev_err(pas->dev, "unable to resolve dtb memory-region\n");
+		return -EINVAL;
+	}
+
+	pas->dtb_mem_phys = pas->dtb_mem_reloc = rmem->base;
+	pas->dtb_mem_size = rmem->size;
+	pas->dtb_mem_region = devm_ioremap_wc(pas->dev, pas->dtb_mem_phys, pas->dtb_mem_size);
 	if (!pas->dtb_mem_region) {
-		dev_err(pas->dev, "unable to map dtb memory region: %pR\n", &res);
+		dev_err(pas->dev, "unable to map dtb memory region: %pa+%zx\n",
+			&rmem->base, pas->dtb_mem_size);
 		return -EBUSY;
 	}
 
@@ -587,6 +603,7 @@ static int qcom_pas_alloc_memory_region(struct qcom_pas *pas)
 static int qcom_pas_assign_memory_region(struct qcom_pas *pas)
 {
 	struct qcom_scm_vmperm perm[MAX_ASSIGN_COUNT];
+	struct device_node *node;
 	unsigned int perm_size;
 	int offset;
 	int ret;
@@ -595,15 +612,17 @@ static int qcom_pas_assign_memory_region(struct qcom_pas *pas)
 		return 0;
 
 	for (offset = 0; offset < pas->region_assign_count; ++offset) {
-		struct resource res;
+		struct reserved_mem *rmem = NULL;
 
-		ret = of_reserved_mem_region_to_resource(pas->dev->of_node,
-							 pas->region_assign_idx + offset,
-							 &res);
-		if (ret) {
+		node = of_parse_phandle(pas->dev->of_node, "memory-region",
+					pas->region_assign_idx + offset);
+		if (node)
+			rmem = of_reserved_mem_lookup(node);
+		of_node_put(node);
+		if (!rmem) {
 			dev_err(pas->dev, "unable to resolve shareable memory-region index %d\n",
 				offset);
-			return ret;
+			return -EINVAL;
 		}
 
 		if (pas->region_assign_shared)  {
@@ -618,8 +637,8 @@ static int qcom_pas_assign_memory_region(struct qcom_pas *pas)
 			perm_size = 1;
 		}
 
-		pas->region_assign_phys[offset] = res.start;
-		pas->region_assign_size[offset] = resource_size(&res);
+		pas->region_assign_phys[offset] = rmem->base;
+		pas->region_assign_size[offset] = rmem->size;
 		pas->region_assign_owners[offset] = BIT(QCOM_SCM_VMID_HLOS);
 
 		ret = qcom_scm_assign_mem(pas->region_assign_phys[offset],

--- a/drivers/remoteproc/qcom_q6v5_wcss.c
+++ b/drivers/remoteproc/qcom_q6v5_wcss.c
@@ -874,22 +874,27 @@ static int q6v5_wcss_init_mmio(struct q6v5_wcss *wcss,
 
 static int q6v5_alloc_memory_region(struct q6v5_wcss *wcss)
 {
+	struct reserved_mem *rmem = NULL;
+	struct device_node *node;
 	struct device *dev = wcss->dev;
-	struct resource res;
-	int ret;
 
-	ret = of_reserved_mem_region_to_resource(dev->of_node, 0, &res);
-	if (ret) {
+	node = of_parse_phandle(dev->of_node, "memory-region", 0);
+	if (node)
+		rmem = of_reserved_mem_lookup(node);
+	of_node_put(node);
+
+	if (!rmem) {
 		dev_err(dev, "unable to acquire memory-region\n");
-		return ret;
+		return -EINVAL;
 	}
 
-	wcss->mem_phys = res.start;
-	wcss->mem_reloc = res.start;
-	wcss->mem_size = resource_size(&res);
-	wcss->mem_region = devm_ioremap_resource_wc(dev, &res);
+	wcss->mem_phys = rmem->base;
+	wcss->mem_reloc = rmem->base;
+	wcss->mem_size = rmem->size;
+	wcss->mem_region = devm_ioremap_wc(dev, wcss->mem_phys, wcss->mem_size);
 	if (!wcss->mem_region) {
-		dev_err(dev, "unable to map memory region: %pR\n", &res);
+		dev_err(dev, "unable to map memory region: %pa+%pa\n",
+			&rmem->base, &rmem->size);
 		return -EBUSY;
 	}
 

--- a/drivers/remoteproc/qcom_q6v5_wcss.c
+++ b/drivers/remoteproc/qcom_q6v5_wcss.c
@@ -888,9 +888,9 @@ static int q6v5_alloc_memory_region(struct q6v5_wcss *wcss)
 	wcss->mem_reloc = res.start;
 	wcss->mem_size = resource_size(&res);
 	wcss->mem_region = devm_ioremap_resource_wc(dev, &res);
-	if (IS_ERR(wcss->mem_region)) {
+	if (!wcss->mem_region) {
 		dev_err(dev, "unable to map memory region: %pR\n", &res);
-		return PTR_ERR(wcss->mem_region);
+		return -EBUSY;
 	}
 
 	return 0;

--- a/drivers/remoteproc/qcom_wcnss.c
+++ b/drivers/remoteproc/qcom_wcnss.c
@@ -456,8 +456,7 @@ static int wcnss_init_regulators(struct qcom_wcnss *wcnss,
 	if (wcnss->num_pds) {
 		info += wcnss->num_pds;
 		/* Handle single power domain case */
-		if (wcnss->num_pds < num_pd_vregs)
-			num_vregs += num_pd_vregs - wcnss->num_pds;
+		num_vregs += num_pd_vregs - wcnss->num_pds;
 	} else {
 		num_vregs += num_pd_vregs;
 	}

--- a/drivers/remoteproc/qcom_wcnss.c
+++ b/drivers/remoteproc/qcom_wcnss.c
@@ -117,10 +117,10 @@ static const struct wcnss_data pronto_v1_data = {
 	.pmu_offset = 0x1004,
 	.spare_offset = 0x1088,
 
-	.pd_names = { "cx", "mx" },
+	.pd_names = { "mx", "cx" },
 	.vregs = (struct wcnss_vreg_info[]) {
-		{ "vddcx", .super_turbo = true},
 		{ "vddmx", 950000, 1150000, 0 },
+		{ "vddcx", .super_turbo = true},
 		{ "vddpx", 1800000, 1800000, 0 },
 	},
 	.num_pd_vregs = 2,
@@ -131,10 +131,10 @@ static const struct wcnss_data pronto_v2_data = {
 	.pmu_offset = 0x1004,
 	.spare_offset = 0x1088,
 
-	.pd_names = { "cx", "mx" },
+	.pd_names = { "mx", "cx" },
 	.vregs = (struct wcnss_vreg_info[]) {
-		{ "vddcx", .super_turbo = true },
 		{ "vddmx", 1287500, 1287500, 0 },
+		{ "vddcx", .super_turbo = true },
 		{ "vddpx", 1800000, 1800000, 0 },
 	},
 	.num_pd_vregs = 2,
@@ -397,16 +397,7 @@ static irqreturn_t wcnss_stop_ack_interrupt(int irq, void *dev)
 static int wcnss_init_pds(struct qcom_wcnss *wcnss,
 			  const char * const pd_names[WCNSS_MAX_PDS])
 {
-	struct device *dev = wcnss->dev;
 	int i, ret;
-
-	/* Handle single power domain */
-	if (dev->pm_domain) {
-		wcnss->pds[0] = dev;
-		wcnss->num_pds = 1;
-		pm_runtime_enable(dev);
-		return 0;
-	}
 
 	for (i = 0; i < WCNSS_MAX_PDS; i++) {
 		if (!pd_names[i])
@@ -427,14 +418,7 @@ static int wcnss_init_pds(struct qcom_wcnss *wcnss,
 
 static void wcnss_release_pds(struct qcom_wcnss *wcnss)
 {
-	struct device *dev = wcnss->dev;
 	int i;
-
-	/* Handle single power domain */
-	if (wcnss->num_pds == 1 && dev->pm_domain) {
-		pm_runtime_disable(dev);
-		return;
-	}
 
 	for (i = 0; i < wcnss->num_pds; i++)
 		dev_pm_domain_detach(wcnss->pds[i], false);
@@ -453,13 +437,10 @@ static int wcnss_init_regulators(struct qcom_wcnss *wcnss,
 	 * the regulators for the power domains. For old device trees we need to
 	 * reserve extra space to manage them through the regulator interface.
 	 */
-	if (wcnss->num_pds) {
-		info += wcnss->num_pds;
-		/* Handle single power domain case */
-		num_vregs += num_pd_vregs - wcnss->num_pds;
-	} else {
+	if (wcnss->num_pds)
+		info += num_pd_vregs;
+	else
 		num_vregs += num_pd_vregs;
-	}
 
 	bulk = devm_kcalloc(wcnss->dev,
 			    num_vregs, sizeof(struct regulator_bulk_data),

--- a/drivers/remoteproc/qcom_wcnss.c
+++ b/drivers/remoteproc/qcom_wcnss.c
@@ -538,9 +538,9 @@ static int wcnss_alloc_memory_region(struct qcom_wcnss *wcnss)
 	wcnss->mem_phys = wcnss->mem_reloc = res.start;
 	wcnss->mem_size = resource_size(&res);
 	wcnss->mem_region = devm_ioremap_resource_wc(wcnss->dev, &res);
-	if (IS_ERR(wcnss->mem_region)) {
+	if (!wcnss->mem_region) {
 		dev_err(wcnss->dev, "unable to map memory region: %pR\n", &res);
-		return PTR_ERR(wcnss->mem_region);
+		return -EBUSY;
 	}
 
 	return 0;

--- a/drivers/remoteproc/qcom_wcnss.c
+++ b/drivers/remoteproc/qcom_wcnss.c
@@ -526,20 +526,25 @@ static int wcnss_request_irq(struct qcom_wcnss *wcnss,
 
 static int wcnss_alloc_memory_region(struct qcom_wcnss *wcnss)
 {
-	struct resource res;
-	int ret;
+	struct reserved_mem *rmem = NULL;
+	struct device_node *node;
 
-	ret = of_reserved_mem_region_to_resource(wcnss->dev->of_node, 0, &res);
-	if (ret) {
+	node = of_parse_phandle(wcnss->dev->of_node, "memory-region", 0);
+	if (node)
+		rmem = of_reserved_mem_lookup(node);
+	of_node_put(node);
+
+	if (!rmem) {
 		dev_err(wcnss->dev, "unable to resolve memory-region\n");
-		return ret;
+		return -EINVAL;
 	}
 
-	wcnss->mem_phys = wcnss->mem_reloc = res.start;
-	wcnss->mem_size = resource_size(&res);
-	wcnss->mem_region = devm_ioremap_resource_wc(wcnss->dev, &res);
+	wcnss->mem_phys = wcnss->mem_reloc = rmem->base;
+	wcnss->mem_size = rmem->size;
+	wcnss->mem_region = devm_ioremap_wc(wcnss->dev, wcnss->mem_phys, wcnss->mem_size);
 	if (!wcnss->mem_region) {
-		dev_err(wcnss->dev, "unable to map memory region: %pR\n", &res);
+		dev_err(wcnss->dev, "unable to map memory region: %pa+%zx\n",
+			&rmem->base, wcnss->mem_size);
 		return -EBUSY;
 	}
 


### PR DESCRIPTION
Fixes issues with bringing up wcnss.
An alternative to wcnss reverts can be this: https://lore.kernel.org/all/674efe8d-c299-4ce9-bf6b-c1920a5393eb@samsung.com/
Regulator reverts are needed for running the kernel compiled with LLVM.