### PR TITLE
arm64: dts: qcom: pm8916: add flag "allow-set-time" to RTC node

### DIFF
--- a/arch/arm64/boot/dts/qcom/pm8916.dtsi
+++ b/arch/arm64/boot/dts/qcom/pm8916.dtsi
@@ -173,6 +173,7 @@
 			reg = <0x6000>, <0x6100>;
 			reg-names = "rtc", "alarm";
 			interrupts = <0x0 0x61 0x1 IRQ_TYPE_EDGE_RISING>;
+			allow-set-time;
 		};
 
 		pm8916_mpps: mpps@a000 {


### PR DESCRIPTION
This flag makes the RTC writable. That way the RTC can get synchronized with the system time.

Reference: https://github.com/msm8916-mainline/linux/blob/wip/msm8916/6.19-rc8/Documentation/devicetree/bindings/rtc/qcom-pm8xxx-rtc.yaml#L38-L41