### PR TITLE
arm64: dts: qcom: msm8916-vivo-pd1505f: Add initial device tree

### DIFF
--- a/Documentation/devicetree/bindings/arm/qcom.yaml
+++ b/Documentation/devicetree/bindings/arm/qcom.yaml
@@ -187,6 +187,7 @@ properties:
               - samsung,serranove
               - thwc,uf896
               - thwc,ufi001c
+              - vivo,pd1505f
               - wiko,chuppito
               - wingtech,wt86518
               - wingtech,wt86528

--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -87,6 +87,7 @@ dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-on7.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-samsung-serranove.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-thwc-uf896.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-thwc-ufi001c.dtb
+dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-vivo-pd1505f.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-vivo-y21l.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-wiko-chuppito.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-wingtech-wt86518.dtb

--- a/arch/arm64/boot/dts/qcom/msm8916-vivo-pd1505f.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-vivo-pd1505f.dts
@@ -121,8 +121,7 @@
 		compatible = "goodix,gt928";
 		reg = <0x14>;
 
-		interrupt-parent = <&tlmm>;
-		interrupts = <13 IRQ_TYPE_EDGE_FALLING>;
+		interrupts-extended = <&tlmm 13 IRQ_TYPE_EDGE_FALLING>;
 
 		irq-gpios = <&tlmm 13 GPIO_ACTIVE_LOW>;
 		reset-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
@@ -158,6 +157,7 @@
 		regulator-min-microvolt = <2850000>;
 		regulator-max-microvolt = <2850000>;
 	};
+
 	pm8916_l17: l17 {
 		regulator-min-microvolt = <2850000>;
 		regulator-max-microvolt = <2850000>;
@@ -245,6 +245,7 @@
 		drive-strength = <8>;
 		bias-pull-up;
 	};
+
 	ts_int_default: ts-int-default-state {
 		pins = "gpio13";
 		function = "gpio";

--- a/arch/arm64/boot/dts/qcom/msm8916-vivo-pd1505f.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-vivo-pd1505f.dts
@@ -1,0 +1,313 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+/dts-v1/;
+
+#include "msm8916-pm8916.dtsi"
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
+#include <dt-bindings/pinctrl/qcom,pmic-mpp.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	model = "Vivo Y31A (PD1505F)";
+	compatible = "pd1505f", "qcom,msm8916";
+	chassis-type = "handset";
+
+	aliases {
+		mmc0 = &sdhc_1;
+		mmc1 = &sdhc_2;
+		serial0 = &blsp_uart2;
+	};
+
+	chosen {
+		stdout-path = "serial0";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&gpio_keys_default>;
+		pinctrl-names = "default";
+		label = "GPIO Buttons";
+
+		button-volume-up {
+			label = "Volume Up";
+			gpios = <&tlmm 107 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_VOLUMEUP>;
+		};
+	};
+
+	usb_id: usb-id {
+		compatible = "linux,extcon-usb-gpio";
+		id-gpios = <&tlmm 110 GPIO_ACTIVE_HIGH>;
+		pinctrl-0 = <&usb_id_default>;
+		pinctrl-names = "default";
+	};
+
+	backlight: backlight {
+		compatible = "pwm-backlight";
+		pwms = <&pm8916_pwm 0 40000>;
+		brightness-levels = <0 255>;
+		num-interpolated-steps = <255>;
+		default-brightness-level = <255>;
+		enable-gpios = <&tlmm 8 GPIO_ACTIVE_HIGH>;
+		pinctrl-0 = <&lcd_bl_en_default>;
+		pinctrl-names = "default";
+		post-pwm-on-delay-ms = <10>;
+		pwm-off-delay-ms = <10>;
+	};
+
+	battery: battery-cell {
+		compatible = "simple-battery";
+		voltage-min-design-microvolt = <3450000>;
+		voltage-max-design-microvolt = <4350000>;
+		energy-full-design-microwatt-hours = <8470000>;
+		charge-full-design-microamp-hours = <2200000>;
+
+		ocv-capacity-celsius = <25>;
+		ocv-capacity-table-0 = <4350000 100>, <4300000 95>, <4250000 90>,
+				       <4200000 85>, <4150000 80>, <4100000 75>,
+				       <4050000 70>, <4000000 65>, <3950000 60>,
+				       <3900000 55>, <3850000 50>, <3820000 45>,
+				       <3800000 40>, <3780000 35>, <3760000 30>,
+				       <3740000 25>, <3720000 20>, <3700000 16>,
+				       <3690000 13>, <3680000 11>, <3670000 10>,
+				       <3660000 9>,  <3650000 8>,  <3640000 7>,
+				       <3600000 6>,  <3550000 5>,  <3500000 4>,
+				       <3450000 3>,  <3400000 2>,  <3300000 1>,
+				       <3000000 0>;
+	};
+};
+
+&blsp_i2c2 {
+	status = "okay";
+
+	accelerometer@18 {
+		compatible = "st,lis3dh-accel";
+		reg = <0x18>;
+		interrupts-extended = <&tlmm 21 IRQ_TYPE_EDGE_RISING>;
+		vdd-supply = <&pm8916_l17>;
+		vddio-supply = <&pm8916_l6>;
+		pinctrl-0 = <&accel_int_default>;
+		pinctrl-names = "default";
+		mount-matrix = "-1", "0", "0",
+				"0", "1", "0",
+				"0", "0", "1";
+	};
+
+	magnetormeter@2e {
+		compatible = "yamaha,yas533";
+		reg = <0x2e>;
+		vdd-supply = <&pm8916_l17>;
+		vddio-supply = <&pm8916_l6>;
+	};
+
+	light-sensor@39 {
+		compatible = "amstaos,tmd2772";
+		reg = <0x39>;
+		interrupts-extended = <&tlmm 113 IRQ_TYPE_EDGE_FALLING>;
+		vdd-supply = <&pm8916_l17>;
+		vddio-supply = <&pm8916_l6>;
+		pinctrl-0 = <&light_int_default>;
+		pinctrl-names = "default";
+	};
+};
+
+&blsp_i2c5 {
+	status = "okay";
+
+	touchscreen@14 {
+		compatible = "goodix,gt928";
+		reg = <0x14>;
+
+		interrup-extended = <&tlmm 13 IRQ_TYPE_EDGE_FALLING>;
+		irq-gpios = <&tlmm 13 GPIO_ACTIVE_LOW>;
+		reset-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
+
+		AVDD28-supply = <&pm8916_l16>;
+		touchscreen-size-x = <540>;
+		touchscreen-size-y = <960>;
+
+		pinctrl-0 = <&ts_int_default>, <&ts_rst_default>;
+		pinctrl-names = "default";
+	};
+};
+
+&blsp_uart2 {
+	status = "okay";
+};
+
+&pm8916_bms {
+	monitored-battery = <&battery>;
+	status = "okay";
+};
+
+&pm8916_resin {
+	linux,code = <KEY_VOLUMEDOWN>;
+	status = "okay";
+};
+
+&pm8916_rpm_regulators {
+	pm8916_l16: l16 {
+		regulator-min-microvolt = <2850000>;
+		regulator-max-microvolt = <2850000>;
+	};
+	pm8916_l17: l17 {
+		regulator-min-microvolt = <2850000>;
+		regulator-max-microvolt = <2850000>;
+	};
+};
+
+&sdhc_1 {
+	status = "okay";
+};
+
+&sdhc_2 {
+	non-removable;
+	status = "okay";
+};
+
+&usb {
+	extcon = <&usb_id>, <&usb_id>;
+	status = "okay";
+};
+
+&usb_hs_phy {
+	extcon = <&usb_id>;
+};
+
+&wcnss {
+	status = "okay";
+};
+
+&wcnss_iris {
+	compatible = "qcom,wcn3620";
+};
+
+&wcnss_mem {
+	status = "okay";
+};
+
+&tlmm {
+	accel_int_default: accel-int-default-state {
+		pins = "gpio21";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	gpio_keys_default: gpio-keys-default-state {
+		pins = "gpio107";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-pull-up;
+	};
+
+	light_int_default: light-int-default-state {
+		pins = "gpio113";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	lcd_bl_en_default: lcd-bl-en-default-state {
+		pins = "gpio8";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	mdss_default: mdss-default-state {
+		pins = "gpio25";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-disable;
+	};
+
+	mdss_sleep: mdss-sleep-state {
+		pins = "gpio25";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-pull-down;
+	};
+
+	usb_id_default: usb-id-default-state {
+		pins = "gpio110";
+		function = "gpio";
+		drive-strength = <8>;
+		bias-pull-up;
+	};
+	ts_int_default: ts-int-default-state {
+		pins = "gpio13";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	ts_rst_default: ts-rst-default-state {
+		pins = "gpio12";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+};
+
+&pm8916_pwm {
+	status = "okay";
+};
+
+&pm8916_mpps {
+	pwm_out: mpp4-state {
+		pins = "mpp4";
+		function = "digital";
+		power-source = <PM8916_MPP_VPH>;
+		output-low;
+		qcom,dtest = <1>;
+	};
+};
+
+&gpu {
+	status = "okay";
+};
+
+&mdss {
+	status = "okay";
+};
+
+&mdss_dsi0 {
+	pinctrl-0 = <&mdss_default>;
+	pinctrl-1 = <&mdss_sleep>;
+	pinctrl-names = "default", "sleep";
+
+	panel@0 {
+		compatible = "vivo,pd1505f-panel";
+		reg = <0>;
+
+		backlight = <&backlight>;
+		vdd-supply = <&pm8916_l17>;
+		vddio-supply = <&pm8916_l6>;
+		reset-gpios = <&tlmm 25 GPIO_ACTIVE_LOW>;
+
+		port {
+			panel_in: endpoint {
+				remote-endpoint = <&mdss_dsi0_out>;
+			};
+		};
+	};
+};
+
+&mdss_dsi0_out {
+	data-lanes = <0 1>;
+	remote-endpoint = <&panel_in>;
+};
+
+&mdss_dsi0_phy {
+	qcom,dsi-phy-regulator-ldo-mode;
+};
+
+&bimc {
+	assigned-clocks = <&gcc BIMC_DDR_CLK_SRC>;
+	assigned-clock-rates = <400000000>;
+};

--- a/arch/arm64/boot/dts/qcom/msm8916-vivo-pd1505f.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-vivo-pd1505f.dts
@@ -5,15 +5,14 @@
 #include "msm8916-pm8916.dtsi"
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/input/input.h>
-#include <dt-bindings/interrupt-controller/irq.h>
-#include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/leds/common.h>
 #include <dt-bindings/pinctrl/qcom,pmic-gpio.h>
 #include <dt-bindings/pinctrl/qcom,pmic-mpp.h>
-#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	model = "Vivo Y31A (PD1505F)";
-	compatible = "pd1505f", "qcom,msm8916";
+	compatible = "vivo,pd1505f", "qcom,msm8916";
 	chassis-type = "handset";
 
 	aliases {
@@ -24,26 +23,6 @@
 
 	chosen {
 		stdout-path = "serial0";
-	};
-
-	gpio-keys {
-		compatible = "gpio-keys";
-		pinctrl-0 = <&gpio_keys_default>;
-		pinctrl-names = "default";
-		label = "GPIO Buttons";
-
-		button-volume-up {
-			label = "Volume Up";
-			gpios = <&tlmm 107 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_VOLUMEUP>;
-		};
-	};
-
-	usb_id: usb-id {
-		compatible = "linux,extcon-usb-gpio";
-		id-gpios = <&tlmm 110 GPIO_ACTIVE_HIGH>;
-		pinctrl-0 = <&usb_id_default>;
-		pinctrl-names = "default";
 	};
 
 	backlight: backlight {
@@ -78,6 +57,26 @@
 				       <3600000 6>,  <3550000 5>,  <3500000 4>,
 				       <3450000 3>,  <3400000 2>,  <3300000 1>,
 				       <3000000 0>;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+		pinctrl-0 = <&gpio_keys_default>;
+		pinctrl-names = "default";
+		label = "GPIO Buttons";
+
+		button-volume-up {
+			label = "Volume Up";
+			gpios = <&tlmm 107 GPIO_ACTIVE_LOW>;
+			linux,code = <KEY_VOLUMEUP>;
+		};
+	};
+
+	usb_id: usb-id {
+		compatible = "linux,extcon-usb-gpio";
+		id-gpios = <&tlmm 110 GPIO_ACTIVE_HIGH>;
+		pinctrl-0 = <&usb_id_default>;
+		pinctrl-names = "default";
 	};
 };
 
@@ -141,11 +140,13 @@
 
 &pm8916_bms {
 	monitored-battery = <&battery>;
+
 	status = "okay";
 };
 
 &pm8916_resin {
 	linux,code = <KEY_VOLUMEDOWN>;
+
 	status = "okay";
 };
 
@@ -166,11 +167,13 @@
 
 &sdhc_2 {
 	non-removable;
+
 	status = "okay";
 };
 
 &usb {
 	extcon = <&usb_id>, <&usb_id>;
+
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/qcom/msm8916-vivo-pd1505f.dts
+++ b/arch/arm64/boot/dts/qcom/msm8916-vivo-pd1505f.dts
@@ -121,11 +121,14 @@
 		compatible = "goodix,gt928";
 		reg = <0x14>;
 
-		interrup-extended = <&tlmm 13 IRQ_TYPE_EDGE_FALLING>;
+		interrupt-parent = <&tlmm>;
+		interrupts = <13 IRQ_TYPE_EDGE_FALLING>;
+
 		irq-gpios = <&tlmm 13 GPIO_ACTIVE_LOW>;
 		reset-gpios = <&tlmm 12 GPIO_ACTIVE_LOW>;
 
 		AVDD28-supply = <&pm8916_l16>;
+		VDDIO-supply = <&pm8916_l6>;
 		touchscreen-size-x = <540>;
 		touchscreen-size-y = <960>;
 


### PR DESCRIPTION
This is the fix for '#442', resubmitted

[https://github.com/msm8916-mainline/linux/pull/442](url)